### PR TITLE
transmuting bytes to str when safe

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jiter"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "ahash",
  "indexmap",


### PR DESCRIPTION
fuzzed quite a lot and it seems to be fine as expected.

I also tried commenting out

```rs
                next if *next >= 128u8 && ascii_only => {
                    ascii_only = false;
                }
```

and fuzz fails almost straight way.