### PR TITLE
Experiment - faster string construction

### DIFF
--- a/src/string_decoder.rs
+++ b/src/string_decoder.rs
@@ -1,4 +1,3 @@
-use std::fmt::Display;
 use std::ops::Range;
 
 use crate::errors::{json_err, json_error, JsonResult};
@@ -28,11 +27,11 @@ where
     Data(&'j str),
 }
 
-impl Display for StringOutput<'_, '_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Tape(s) => write!(f, "{}", s),
-            Self::Data(s) => write!(f, "{}", s),
+impl From<StringOutput<'_, '_>> for String {
+    fn from(val: StringOutput) -> Self {
+        match val {
+            StringOutput::Tape(s) => s.to_owned(),
+            StringOutput::Data(s) => s.to_owned(),
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -100,7 +100,7 @@ pub(crate) fn take_value(
         }
         Peak::String => {
             let s = parser.consume_string::<StringDecoder>(tape)?;
-            Ok(JsonValue::Str(s.to_string()))
+            Ok(JsonValue::Str(s.into()))
         }
         Peak::Num(first) => {
             let n = parser.consume_number::<NumberAny>(first, allow_inf_nan)?;
@@ -131,14 +131,14 @@ pub(crate) fn take_value(
             // same for objects
             let mut object: LazyIndexMap<String, JsonValue> = LazyIndexMap::new();
             if let Some(first_key) = parser.object_first::<StringDecoder>(tape)? {
-                let first_key = first_key.to_string();
+                let first_key = first_key.into();
                 let peak = parser.peak()?;
                 check_recursion!(recursion_limit, parser.index,
                     let first_value = take_value(peak, parser, tape, recursion_limit, allow_inf_nan)?;
                 );
                 object.insert(first_key, first_value);
                 while let Some(key) = parser.object_step::<StringDecoder>(tape)? {
-                    let key = key.to_string();
+                    let key = key.into();
                     let peak = parser.peak()?;
                     check_recursion!(recursion_limit, parser.index,
                         let value = take_value(peak, parser, tape, recursion_limit, allow_inf_nan)?;


### PR DESCRIPTION
Seems to be successful.

I noticed in codspeed lots of calls to `fmt` etc. which was weird for parsing JSON, turned out the use of the `Display` trait to convert `StringOutput` `String`s was not being optimised properly, this fixed it