### PR TITLE
Replace `peak` with more efficient `peek`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Object(
 To use [Jiter], you need to know what schema you're expecting:
 
 ```rust
-use jiter::{Jiter, NumberInt, Peak};
+use jiter::{Jiter, NumberInt, Peek};
 
 fn main() {
     let json_data = r#"
@@ -75,10 +75,10 @@ fn main() {
     assert_eq!(jiter.next_key().unwrap(), Some("age"));
     assert_eq!(jiter.next_int().unwrap(), NumberInt::Int(43));
     assert_eq!(jiter.next_key().unwrap(), Some("phones"));
-    assert_eq!(jiter.next_array().unwrap(), Some(Peak::String));
+    assert_eq!(jiter.next_array().unwrap(), Some(Peek::String));
     // we know the next value is a string as we just asserted so
     assert_eq!(jiter.known_str().unwrap(), "+44 1234567");
-    assert_eq!(jiter.array_step().unwrap(), Some(Peak::String));
+    assert_eq!(jiter.array_step().unwrap(), Some(Peek::String));
     // same again
     assert_eq!(jiter.known_str().unwrap(), "+44 2345678");
     // next we'll get `None` from `array_step` as the array is finished

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -4,7 +4,7 @@ use std::hint::black_box;
 use std::fs::File;
 use std::io::Read;
 
-use jiter::{Jiter, JsonValue, Peak};
+use jiter::{Jiter, JsonValue, Peek};
 use serde_json::Value;
 
 fn read_file(path: &str) -> String {
@@ -31,11 +31,11 @@ fn jiter_iter_big(path: &str, bench: &mut Bencher) {
         jiter.next_array().unwrap();
 
         loop {
-            if let Some(peak) = jiter.next_array().unwrap() {
-                let i = jiter.known_float(peak).unwrap();
+            if let Some(peek) = jiter.next_array().unwrap() {
+                let i = jiter.known_float(peek).unwrap();
                 black_box(i);
-                while let Some(peak) = jiter.array_step().unwrap() {
-                    let i = jiter.known_float(peak).unwrap();
+                while let Some(peek) = jiter.array_step().unwrap() {
+                    let i = jiter.known_float(peek).unwrap();
                     black_box(i);
                 }
             }
@@ -47,10 +47,10 @@ fn jiter_iter_big(path: &str, bench: &mut Bencher) {
 }
 
 fn find_string(jiter: &mut Jiter) -> String {
-    let peak = jiter.peak().unwrap();
-    match peak {
-        Peak::String => jiter.known_str().unwrap().to_string(),
-        Peak::Array => {
+    let peek = jiter.peek().unwrap();
+    match peek {
+        Peek::String => jiter.known_str().unwrap().to_string(),
+        Peek::Array => {
             assert!(jiter.known_array().unwrap().is_some());
             let s = find_string(jiter).to_string();
             assert!(jiter.array_step().unwrap().is_none());
@@ -93,11 +93,11 @@ fn jiter_iter_true_array(path: &str, bench: &mut Bencher) {
     let json_data = black_box(json.as_bytes());
     bench.iter(|| {
         let mut jiter = Jiter::new(json_data, false);
-        let first_peak = jiter.next_array().unwrap().unwrap();
-        let i = jiter.known_bool(first_peak).unwrap();
+        let first_peek = jiter.next_array().unwrap().unwrap();
+        let i = jiter.known_bool(first_peek).unwrap();
         black_box(i);
-        while let Some(peak) = jiter.array_step().unwrap() {
-            let i = jiter.known_bool(peak).unwrap();
+        while let Some(peek) = jiter.array_step().unwrap() {
+            let i = jiter.known_bool(peek).unwrap();
             black_box(i);
         }
     })
@@ -126,11 +126,11 @@ fn jiter_iter_ints_array(path: &str, bench: &mut Bencher) {
     let json_data = black_box(json.as_bytes());
     bench.iter(|| {
         let mut jiter = Jiter::new(json_data, false);
-        let first_peak = jiter.next_array().unwrap().unwrap();
-        let i = jiter.known_int(first_peak).unwrap();
+        let first_peek = jiter.next_array().unwrap().unwrap();
+        let i = jiter.known_int(first_peek).unwrap();
         black_box(i);
-        while let Some(peak) = jiter.array_step().unwrap() {
-            let i = jiter.known_int(peak).unwrap();
+        while let Some(peek) = jiter.array_step().unwrap() {
+            let i = jiter.known_int(peek).unwrap();
             black_box(i);
         }
     })
@@ -141,11 +141,11 @@ fn jiter_iter_floats_array(path: &str, bench: &mut Bencher) {
     let json_data = black_box(json.as_bytes());
     bench.iter(|| {
         let mut jiter = Jiter::new(json_data, false);
-        let first_peak = jiter.next_array().unwrap().unwrap();
-        let i = jiter.known_float(first_peak).unwrap();
+        let first_peek = jiter.next_array().unwrap().unwrap();
+        let i = jiter.known_float(first_peek).unwrap();
         black_box(i);
-        while let Some(peak) = jiter.array_step().unwrap() {
-            let i = jiter.known_float(peak).unwrap();
+        while let Some(peek) = jiter.array_step().unwrap() {
+            let i = jiter.known_float(peek).unwrap();
             black_box(i);
         }
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub use errors::{JiterErrorType, JsonError, JsonErrorType, JsonResult, JsonType,
 pub use jiter::{Jiter, JiterResult};
 pub use lazy_index_map::LazyIndexMap;
 pub use number_decoder::{NumberAny, NumberInt};
-pub use parse::Peak;
+pub use parse::Peek;
 pub use value::{JsonArray, JsonObject, JsonValue};
 
 #[cfg(feature = "python")]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -10,18 +10,7 @@ impl Peak {
     pub const Null: Self = Self(b'n');
     pub const True: Self = Self(b't');
     pub const False: Self = Self(b'f');
-    pub const Zero: Self = Self(b'0');
-    pub const One: Self = Self(b'1');
-    pub const Two: Self = Self(b'2');
-    pub const Three: Self = Self(b'3');
-    pub const Four: Self = Self(b'4');
-    pub const Five: Self = Self(b'5');
-    pub const Six: Self = Self(b'6');
-    pub const Seven: Self = Self(b'7');
-    pub const Eight: Self = Self(b'8');
-    pub const Nine: Self = Self(b'9');
     pub const Minus: Self = Self(b'-');
-    pub const Plus: Self = Self(b'+');
     pub const Infinity: Self = Self(b'I');
     pub const NaN: Self = Self(b'N');
     pub const String: Self = Self(b'"');
@@ -35,23 +24,7 @@ impl Peak {
     }
 
     pub const fn is_num(self) -> bool {
-        matches!(
-            self,
-            Self::Zero
-                | Self::One
-                | Self::Two
-                | Self::Three
-                | Self::Four
-                | Self::Five
-                | Self::Six
-                | Self::Seven
-                | Self::Eight
-                | Self::Nine
-                | Self::Minus
-                | Self::Plus
-                | Self::Infinity
-                | Self::NaN
-        )
+        self.0.is_ascii_digit() || matches!(self, Self::Minus | Self::Infinity | Self::NaN)
     }
 
     pub const fn into_inner(self) -> u8 {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,10 +3,10 @@ use crate::number_decoder::AbstractNumberDecoder;
 use crate::string_decoder::{AbstractStringDecoder, Tape};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct Peak(u8);
+pub struct Peek(u8);
 
 #[allow(non_upper_case_globals)] // while testing
-impl Peak {
+impl Peek {
     pub const Null: Self = Self(b'n');
     pub const True: Self = Self(b't');
     pub const False: Self = Self(b'f');
@@ -18,7 +18,7 @@ impl Peak {
     pub const Object: Self = Self(b'{');
 }
 
-impl Peak {
+impl Peek {
     const fn new(next: u8) -> Self {
         Self(next)
     }
@@ -55,34 +55,34 @@ impl<'j> Parser<'j> {
         LinePosition::find(self.data, self.index)
     }
 
-    pub fn peak(&mut self) -> JsonResult<Peak> {
+    pub fn peek(&mut self) -> JsonResult<Peek> {
         if let Some(next) = self.eat_whitespace() {
-            Ok(Peak::new(next))
+            Ok(Peek::new(next))
         } else {
             json_err!(EofWhileParsingValue, self.index)
         }
     }
 
-    pub fn array_first(&mut self) -> JsonResult<Option<Peak>> {
+    pub fn array_first(&mut self) -> JsonResult<Option<Peek>> {
         self.index += 1;
         if let Some(next) = self.eat_whitespace() {
             if next == b']' {
                 self.index += 1;
                 Ok(None)
             } else {
-                Ok(Some(Peak::new(next)))
+                Ok(Some(Peek::new(next)))
             }
         } else {
             json_err!(EofWhileParsingList, self.index)
         }
     }
 
-    pub fn array_step(&mut self) -> JsonResult<Option<Peak>> {
+    pub fn array_step(&mut self) -> JsonResult<Option<Peek>> {
         if let Some(next) = self.eat_whitespace() {
             match next {
                 b',' => {
                     self.index += 1;
-                    let next = self.array_peak()?;
+                    let next = self.array_peek()?;
                     if next.is_none() {
                         json_err!(TrailingComma, self.index)
                     } else {
@@ -216,11 +216,11 @@ impl<'j> Parser<'j> {
         Ok(())
     }
 
-    fn array_peak(&mut self) -> JsonResult<Option<Peak>> {
+    fn array_peek(&mut self) -> JsonResult<Option<Peek>> {
         if let Some(next) = self.eat_whitespace() {
             match next {
                 b']' => Ok(None),
-                _ => Ok(Some(Peak::new(next))),
+                _ => Ok(Some(Peek::new(next))),
             }
         } else {
             json_err!(EofWhileParsingValue, self.index)

--- a/src/python.rs
+++ b/src/python.rs
@@ -75,14 +75,6 @@ impl<'j> PythonParser<'j> {
                 let s = self.parser.consume_string::<StringDecoder>(&mut self.tape)?;
                 Ok(StringCache::get(py, s.as_str()))
             }
-            Peak::Num(first) => {
-                let n = self.parser.consume_number::<NumberAny>(first, self.allow_inf_nan)?;
-                match n {
-                    NumberAny::Int(NumberInt::Int(int)) => Ok(int.to_object(py)),
-                    NumberAny::Int(NumberInt::BigInt(big_int)) => Ok(big_int.to_object(py)),
-                    NumberAny::Float(float) => Ok(float.to_object(py)),
-                }
-            }
             Peak::Array => {
                 let list = if let Some(peak_first) = self.parser.array_first()? {
                     let mut vec: SmallVec<[PyObject; 8]> = SmallVec::with_capacity(8);
@@ -124,6 +116,16 @@ impl<'j> PythonParser<'j> {
                     }
                 }
                 Ok(dict.to_object(py))
+            }
+            _ => {
+                let n = self
+                    .parser
+                    .consume_number::<NumberAny>(peak.into_inner(), self.allow_inf_nan)?;
+                match n {
+                    NumberAny::Int(NumberInt::Int(int)) => Ok(int.to_object(py)),
+                    NumberAny::Int(NumberInt::BigInt(big_int)) => Ok(big_int.to_object(py)),
+                    NumberAny::Float(float) => Ok(float.to_object(py)),
+                }
             }
         }
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -11,7 +11,7 @@ use smallvec::SmallVec;
 
 use crate::errors::{json_err, JsonError, JsonResult, DEFAULT_RECURSION_LIMIT};
 use crate::number_decoder::{NumberAny, NumberInt};
-use crate::parse::{Parser, Peak};
+use crate::parse::{Parser, Peek};
 use crate::string_decoder::{StringDecoder, Tape};
 
 /// Parse a JSON value from a byte slice and return a Python object.
@@ -34,11 +34,11 @@ pub fn python_parse(py: Python, json_data: &[u8], allow_inf_nan: bool, cache_str
         allow_inf_nan,
     };
 
-    let peak = python_parser.parser.peak()?;
+    let peek = python_parser.parser.peek()?;
     let v = if cache_strings {
-        python_parser.py_take_value::<StringCache>(py, peak)?
+        python_parser.py_take_value::<StringCache>(py, peek)?
     } else {
-        python_parser.py_take_value::<StringNoCache>(py, peak)?
+        python_parser.py_take_value::<StringNoCache>(py, peek)?
     };
     python_parser.parser.finish()?;
     Ok(v)
@@ -57,31 +57,31 @@ struct PythonParser<'j> {
 }
 
 impl<'j> PythonParser<'j> {
-    fn py_take_value<StringCache: StringMaybeCache>(&mut self, py: Python, peak: Peak) -> JsonResult<PyObject> {
-        match peak {
-            Peak::True => {
+    fn py_take_value<StringCache: StringMaybeCache>(&mut self, py: Python, peek: Peek) -> JsonResult<PyObject> {
+        match peek {
+            Peek::True => {
                 self.parser.consume_true()?;
                 Ok(true.to_object(py))
             }
-            Peak::False => {
+            Peek::False => {
                 self.parser.consume_false()?;
                 Ok(false.to_object(py))
             }
-            Peak::Null => {
+            Peek::Null => {
                 self.parser.consume_null()?;
                 Ok(py.None())
             }
-            Peak::String => {
+            Peek::String => {
                 let s = self.parser.consume_string::<StringDecoder>(&mut self.tape)?;
                 Ok(StringCache::get(py, s.as_str()))
             }
-            Peak::Array => {
-                let list = if let Some(peak_first) = self.parser.array_first()? {
+            Peek::Array => {
+                let list = if let Some(peek_first) = self.parser.array_first()? {
                     let mut vec: SmallVec<[PyObject; 8]> = SmallVec::with_capacity(8);
-                    let v = self._check_take_value::<StringCache>(py, peak_first)?;
+                    let v = self._check_take_value::<StringCache>(py, peek_first)?;
                     vec.push(v);
-                    while let Some(peak) = self.parser.array_step()? {
-                        let v = self._check_take_value::<StringCache>(py, peak)?;
+                    while let Some(peek) = self.parser.array_step()? {
+                        let v = self._check_take_value::<StringCache>(py, peek)?;
                         vec.push(v);
                     }
                     PyList::new(py, vec)
@@ -90,7 +90,7 @@ impl<'j> PythonParser<'j> {
                 };
                 Ok(list.to_object(py))
             }
-            Peak::Object => {
+            Peek::Object => {
                 let dict = PyDict::new(py);
 
                 let set_item = |key: PyObject, value: PyObject| {
@@ -105,13 +105,13 @@ impl<'j> PythonParser<'j> {
 
                 if let Some(first_key) = self.parser.object_first::<StringDecoder>(&mut self.tape)? {
                     let first_key = StringCache::get(py, first_key.as_str());
-                    let peak = self.parser.peak()?;
-                    let first_value = self._check_take_value::<StringCache>(py, peak)?;
+                    let peek = self.parser.peek()?;
+                    let first_value = self._check_take_value::<StringCache>(py, peek)?;
                     set_item(first_key, first_value);
                     while let Some(key) = self.parser.object_step::<StringDecoder>(&mut self.tape)? {
                         let key = StringCache::get(py, key.as_str());
-                        let peak = self.parser.peak()?;
-                        let value = self._check_take_value::<StringCache>(py, peak)?;
+                        let peek = self.parser.peek()?;
+                        let value = self._check_take_value::<StringCache>(py, peek)?;
                         set_item(key, value);
                     }
                 }
@@ -120,7 +120,7 @@ impl<'j> PythonParser<'j> {
             _ => {
                 let n = self
                     .parser
-                    .consume_number::<NumberAny>(peak.into_inner(), self.allow_inf_nan)?;
+                    .consume_number::<NumberAny>(peek.into_inner(), self.allow_inf_nan)?;
                 match n {
                     NumberAny::Int(NumberInt::Int(int)) => Ok(int.to_object(py)),
                     NumberAny::Int(NumberInt::BigInt(big_int)) => Ok(big_int.to_object(py)),
@@ -130,13 +130,13 @@ impl<'j> PythonParser<'j> {
         }
     }
 
-    fn _check_take_value<StringCache: StringMaybeCache>(&mut self, py: Python, peak: Peak) -> JsonResult<PyObject> {
+    fn _check_take_value<StringCache: StringMaybeCache>(&mut self, py: Python, peek: Peek) -> JsonResult<PyObject> {
         self.recursion_limit = match self.recursion_limit.checked_sub(1) {
             Some(limit) => limit,
             None => return json_err!(RecursionLimitExceeded, self.parser.index),
         };
 
-        let r = self.py_take_value::<StringCache>(py, peak);
+        let r = self.py_take_value::<StringCache>(py, peek);
 
         self.recursion_limit += 1;
         r

--- a/src/value.rs
+++ b/src/value.rs
@@ -144,7 +144,7 @@ pub(crate) fn take_value(
                 Ok(NumberAny::Float(float)) => Ok(JsonValue::Float(float)),
                 Err(e) => {
                     if !peak.is_num() {
-                        Err(json_error!(ExpectedSomeValue, self.parser.index).into())
+                        Err(json_error!(ExpectedSomeValue, parser.index).into())
                     } else {
                         Err(e.into())
                     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -144,9 +144,9 @@ pub(crate) fn take_value(
                 Ok(NumberAny::Float(float)) => Ok(JsonValue::Float(float)),
                 Err(e) => {
                     if !peak.is_num() {
-                        Err(json_error!(ExpectedSomeValue, parser.index).into())
+                        Err(json_error!(ExpectedSomeValue, parser.index))
                     } else {
-                        Err(e.into())
+                        Err(e)
                     }
                 }
             }

--- a/src/value.rs
+++ b/src/value.rs
@@ -97,14 +97,6 @@ pub(crate) fn take_value(
             let s = parser.consume_string::<StringDecoder>(tape)?;
             Ok(JsonValue::Str(s.into()))
         }
-        Peak::Num(first) => {
-            let n = parser.consume_number::<NumberAny>(first, allow_inf_nan)?;
-            match n {
-                NumberAny::Int(NumberInt::Int(int)) => Ok(JsonValue::Int(int)),
-                NumberAny::Int(NumberInt::BigInt(big_int)) => Ok(JsonValue::BigInt(big_int)),
-                NumberAny::Float(float) => Ok(JsonValue::Float(float)),
-            }
-        }
         Peak::Array => {
             // we could do something clever about guessing the size of the array
             let mut array: SmallVec<[JsonValue; 8]> = SmallVec::new();
@@ -143,6 +135,14 @@ pub(crate) fn take_value(
             }
 
             Ok(JsonValue::Object(Arc::new(object)))
+        }
+        _ => {
+            let n = parser.consume_number::<NumberAny>(peak.into_inner(), allow_inf_nan)?;
+            match n {
+                NumberAny::Int(NumberInt::Int(int)) => Ok(JsonValue::Int(int)),
+                NumberAny::Int(NumberInt::BigInt(big_int)) => Ok(JsonValue::BigInt(big_int)),
+                NumberAny::Float(float) => Ok(JsonValue::Float(float)),
+            }
         }
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -630,7 +630,7 @@ fn jiter_object() {
     assert_eq!(jiter.next_object().unwrap(), Some("foo"));
     assert_eq!(jiter.next_str().unwrap(), "bar");
     assert_eq!(jiter.next_key().unwrap(), Some("spam"));
-    assert_eq!(jiter.next_array().unwrap(), Some(Peak::One));
+    assert_eq!(jiter.next_array().unwrap().unwrap().into_inner(), b'1');
     assert_eq!(jiter.next_int().unwrap(), NumberInt::Int(1));
     assert_eq!(jiter.array_step().unwrap(), Some(Peak::Minus));
     assert_eq!(jiter.next_int().unwrap(), NumberInt::Int(-2));
@@ -681,20 +681,20 @@ fn jiter_bytes() {
 #[test]
 fn jiter_number() {
     let mut jiter = Jiter::new(br#"  [1, 2.2, 3, 4.1, 5.67]"#, false);
-    assert_eq!(jiter.next_array().unwrap(), Some(Peak::One));
+    assert_eq!(jiter.next_array().unwrap().unwrap().into_inner(), b'1');
     assert_eq!(jiter.next_int().unwrap(), NumberInt::Int(1));
-    assert_eq!(jiter.array_step().unwrap(), Some(Peak::Two));
+    assert_eq!(jiter.array_step().unwrap().unwrap().into_inner(), b'2');
     assert_eq!(jiter.next_float().unwrap(), 2.2);
-    assert_eq!(jiter.array_step().unwrap(), Some(Peak::Three));
+    assert_eq!(jiter.array_step().unwrap().unwrap().into_inner(), b'3');
 
     let n = jiter.next_number().unwrap();
     assert_eq!(n, NumberAny::Int(NumberInt::Int(3)));
     let n_float: f64 = n.into();
     assert_eq!(n_float, 3.0);
 
-    assert_eq!(jiter.array_step().unwrap(), Some(Peak::Four));
+    assert_eq!(jiter.array_step().unwrap().unwrap().into_inner(), b'4');
     assert_eq!(jiter.next_number().unwrap(), NumberAny::Float(4.1));
-    assert_eq!(jiter.array_step().unwrap(), Some(Peak::Five));
+    assert_eq!(jiter.array_step().unwrap().unwrap().into_inner(), b'5');
     assert_eq!(jiter.next_number_bytes().unwrap(), b"5.67");
     assert_eq!(jiter.array_step().unwrap(), None);
     jiter.finish().unwrap();
@@ -726,7 +726,7 @@ fn jiter_empty_array() {
 #[test]
 fn jiter_trailing_bracket() {
     let mut jiter = Jiter::new(b"[1]]", false);
-    assert_eq!(jiter.next_array().unwrap(), Some(Peak::One));
+    assert_eq!(jiter.next_array().unwrap().unwrap().into_inner(), b'1');
     assert_eq!(jiter.next_int().unwrap(), NumberInt::Int(1));
     assert!(jiter.array_step().unwrap().is_none());
     let e = jiter.finish().unwrap_err();
@@ -914,17 +914,17 @@ fn readme_jiter() {
 fn jiter_clone() {
     let json = r#"[1, 2]"#;
     let mut jiter1 = Jiter::new(json.as_bytes(), false);
-    assert_eq!(jiter1.next_array().unwrap().unwrap(), Peak::One);
+    assert_eq!(jiter1.next_array().unwrap().unwrap().into_inner(), b'1');
     let n = jiter1.next_number().unwrap();
     assert_eq!(n, NumberAny::Int(NumberInt::Int(1)));
 
     let mut jiter2 = jiter1.clone();
 
-    assert_eq!(jiter1.array_step().unwrap().unwrap(), Peak::Two);
+    assert_eq!(jiter1.array_step().unwrap().unwrap().into_inner(), b'2');
     let n = jiter1.next_number().unwrap();
     assert_eq!(n, NumberAny::Int(NumberInt::Int(2)));
 
-    assert_eq!(jiter2.array_step().unwrap().unwrap(), Peak::Two);
+    assert_eq!(jiter2.array_step().unwrap().unwrap().into_inner(), b'2');
     let n = jiter2.next_number().unwrap();
     assert_eq!(n, NumberAny::Int(NumberInt::Int(2)));
 


### PR DESCRIPTION
Attempts to make converting peak to u8 zero cost.

WIP need to correct the numerical branches to handle invalid bytes (because that's the only place where peak may now error).