### PR TITLE
search the `Vec` for small `LazyIndexMap`s

### DIFF
--- a/src/lazy_index_map.rs
+++ b/src/lazy_index_map.rs
@@ -66,7 +66,7 @@ where
     }
 
     pub fn is_empty(&self) -> bool {
-        self.get_map().is_empty()
+        self.vec.is_empty()
     }
 
     pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>

--- a/src/lazy_index_map.rs
+++ b/src/lazy_index_map.rs
@@ -10,11 +10,20 @@ use ahash::AHashMap;
 use smallvec::SmallVec;
 
 /// Like [IndexMap](https://docs.rs/indexmap/latest/indexmap/) but only builds the lookup map when it's needed.
-#[derive(Default)]
 pub struct LazyIndexMap<K, V> {
     vec: SmallVec<[(K, V); 8]>,
     map: OnceLock<AHashMap<K, usize>>,
     last_find: AtomicUsize,
+}
+
+impl<K, V> Default for LazyIndexMap<K, V>
+where
+    K: Clone + fmt::Debug + Eq + Hash,
+    V: fmt::Debug,
+{
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<K: Clone, V: Clone> Clone for LazyIndexMap<K, V> {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -875,9 +875,13 @@ fn test_4302_int_err() {
 #[test]
 fn lazy_index_map_pretty() {
     let mut map = LazyIndexMap::new();
+    assert!(map.is_empty());
     map.insert("foo".to_string(), JsonValue::Str("bar".to_string()));
+    assert!(!map.is_empty());
     map.insert("spam".to_string(), JsonValue::Null);
     assert_eq!(format!("{map:?}"), r#"{"foo": Str("bar"), "spam": Null}"#);
+    let keys = map.keys().collect::<Vec<_>>();
+    assert_eq!(keys, vec!["foo", "spam"]);
 }
 
 #[test]

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -894,6 +894,7 @@ fn lazy_index_map_small_get() {
     assert_eq!(map.get("spam"), Some(&JsonValue::Null));
     assert_eq!(map.get("spam"), Some(&JsonValue::Null));
     assert_eq!(map.get("foo"), Some(&JsonValue::Str("bar".to_string())));
+    assert_eq!(map.get("other"), None);
 }
 
 #[test]
@@ -908,6 +909,7 @@ fn lazy_index_map_big_get() {
     assert_eq!(map.get("0"), Some(&JsonValue::Int(0)));
     assert_eq!(map.get("10"), Some(&JsonValue::Int(10)));
     assert_eq!(map.get("22"), Some(&JsonValue::Int(22)));
+    assert_eq!(map.get("other"), None);
 }
 
 #[test]

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -913,6 +913,27 @@ fn lazy_index_map_big_get() {
 }
 
 #[test]
+fn lazy_index_map_clone() {
+    let mut map = LazyIndexMap::default();
+
+    map.insert("foo".to_string(), JsonValue::Str("bar".to_string()));
+    map.insert("spam".to_string(), JsonValue::Null);
+
+    assert_eq!(map.get("foo"), Some(&JsonValue::Str("bar".to_string())));
+    assert_eq!(map.get("spam"), Some(&JsonValue::Null));
+    assert_eq!(map.get("spam"), Some(&JsonValue::Null));
+    assert_eq!(map.get("foo"), Some(&JsonValue::Str("bar".to_string())));
+    assert_eq!(map.get("other"), None);
+
+    let map2 = map.clone();
+    assert_eq!(map2.get("foo"), Some(&JsonValue::Str("bar".to_string())));
+    assert_eq!(map2.get("spam"), Some(&JsonValue::Null));
+    assert_eq!(map2.get("spam"), Some(&JsonValue::Null));
+    assert_eq!(map2.get("foo"), Some(&JsonValue::Str("bar".to_string())));
+    assert_eq!(map2.get("other"), None);
+}
+
+#[test]
 fn readme_jiter() {
     let json_data = r#"
         {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -873,11 +873,37 @@ fn test_4302_int_err() {
 }
 
 #[test]
-fn lazy_index_map_prety() {
+fn lazy_index_map_pretty() {
     let mut map = LazyIndexMap::new();
     map.insert("foo".to_string(), JsonValue::Str("bar".to_string()));
     map.insert("spam".to_string(), JsonValue::Null);
     assert_eq!(format!("{map:?}"), r#"{"foo": Str("bar"), "spam": Null}"#);
+}
+
+#[test]
+fn lazy_index_map_small_get() {
+    let mut map = LazyIndexMap::new();
+    map.insert("foo".to_string(), JsonValue::Str("bar".to_string()));
+    map.insert("spam".to_string(), JsonValue::Null);
+
+    assert_eq!(map.get("foo"), Some(&JsonValue::Str("bar".to_string())));
+    assert_eq!(map.get("spam"), Some(&JsonValue::Null));
+    assert_eq!(map.get("spam"), Some(&JsonValue::Null));
+    assert_eq!(map.get("foo"), Some(&JsonValue::Str("bar".to_string())));
+}
+
+#[test]
+fn lazy_index_map_big_get() {
+    let mut map = LazyIndexMap::new();
+
+    for i in 0..25 {
+        let key = i.to_string();
+        map.insert(key, JsonValue::Int(i));
+    }
+
+    assert_eq!(map.get("0"), Some(&JsonValue::Int(0)));
+    assert_eq!(map.get("10"), Some(&JsonValue::Int(10)));
+    assert_eq!(map.get("22"), Some(&JsonValue::Int(22)));
 }
 
 #[test]


### PR DESCRIPTION
Instead of creating a `HashMap` when there are very few elements in the `LazyIndexMap`, just lookup the original `Vec`. We store and start from the position of the last find to improve performance in the common case that the input JSON matches the order of the model being constructed

the threshold is set to `16` based on the following benchmarks:


## with hashmap

```
test lazy_map_lookup_1_10           ... bench:         903 ns/iter (+/- 50)
test lazy_map_lookup_2_20           ... bench:       1,726 ns/iter (+/- 54)
test lazy_map_lookup_3_50           ... bench:       4,171 ns/iter (+/- 43)
test lazy_map_lookup_4_100          ... bench:       8,187 ns/iter (+/- 129)
test lazy_map_lookup_5_200          ... bench:      16,547 ns/iter (+/- 197)
test lazy_map_lookup_6_500          ... bench:      39,541 ns/iter (+/- 1,299)
test lazy_map_lookup_7_1000         ... bench:      81,937 ns/iter (+/- 832)
```


## vec best

```
test lazy_map_lookup_1_10           ... bench:         613 ns/iter (+/- 8)
test lazy_map_lookup_2_20           ... bench:       1,210 ns/iter (+/- 11)
test lazy_map_lookup_3_50           ... bench:       2,870 ns/iter (+/- 66)
test lazy_map_lookup_4_100          ... bench:       5,573 ns/iter (+/- 177)
test lazy_map_lookup_5_200          ... bench:      11,138 ns/iter (+/- 358)
test lazy_map_lookup_6_500          ... bench:      27,648 ns/iter (+/- 418)
test lazy_map_lookup_7_1000         ... bench:      55,863 ns/iter (+/- 2,435)
```

## vec worst

```
test lazy_map_lookup_1_10           ... bench:         836 ns/iter (+/- 14)
test lazy_map_lookup_2_20           ... bench:       2,057 ns/iter (+/- 29)
test lazy_map_lookup_3_50           ... bench:      10,068 ns/iter (+/- 138)
test lazy_map_lookup_4_100          ... bench:      35,480 ns/iter (+/- 449)
test lazy_map_lookup_5_200          ... bench:      99,785 ns/iter (+/- 2,516)
test lazy_map_lookup_6_500          ... bench:     667,054 ns/iter (+/- 8,748)
test lazy_map_lookup_7_1000         ... bench:   2,862,108 ns/iter (+/- 46,693)
```

## vec random

```
test lazy_map_lookup_1_10           ... bench:         787 ns/iter (+/- 106)
test lazy_map_lookup_2_20           ... bench:       1,687 ns/iter (+/- 215)
test lazy_map_lookup_3_50           ... bench:       7,084 ns/iter (+/- 795)
test lazy_map_lookup_4_100          ... bench:      22,411 ns/iter (+/- 3,636)
test lazy_map_lookup_5_200          ... bench:      61,810 ns/iter (+/- 6,717)
test lazy_map_lookup_6_500          ... bench:     389,558 ns/iter (+/- 24,424)
test lazy_map_lookup_7_1000         ... bench:   1,597,234 ns/iter (+/- 89,720)
```
