### PR TITLE
move from lexical-core to depend on lexical-parse-float directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ num-traits = "0.2.16"
 ahash = "0.8.0"
 smallvec = "1.11.0"
 pyo3 = { version = "0.20.0", features = ["num-bigint"], optional = true }
-lexical-core = { version = "0.8.5", features = ["format"] }
+lexical-parse-float = { version = "0.8.5", features =  ["format"] }
 hashbrown = "0.14.3"
 
 [features]

--- a/src/number_decoder.rs
+++ b/src/number_decoder.rs
@@ -2,8 +2,8 @@ use num_bigint::BigInt;
 use num_traits::cast::ToPrimitive;
 use std::ops::Range;
 
-use lexical_parse_float::{FromLexicalWithOptions, format as lexical_format, Options as ParseFloatOptions};
 use crate::errors::{json_err, JsonResult};
+use lexical_parse_float::{format as lexical_format, FromLexicalWithOptions, Options as ParseFloatOptions};
 
 pub trait AbstractNumberDecoder {
     type Output;

--- a/src/number_decoder.rs
+++ b/src/number_decoder.rs
@@ -1,9 +1,10 @@
-use num_bigint::BigInt;
-use num_traits::cast::ToPrimitive;
 use std::ops::Range;
 
-use crate::errors::{json_err, JsonResult};
 use lexical_parse_float::{format as lexical_format, FromLexicalWithOptions, Options as ParseFloatOptions};
+use num_bigint::BigInt;
+use num_traits::cast::ToPrimitive;
+
+use crate::errors::{json_err, JsonResult};
 
 pub trait AbstractNumberDecoder {
     type Output;

--- a/src/number_decoder.rs
+++ b/src/number_decoder.rs
@@ -2,8 +2,7 @@ use num_bigint::BigInt;
 use num_traits::cast::ToPrimitive;
 use std::ops::Range;
 
-use lexical_core::{format as lexical_format, parse_partial_with_options, ParseFloatOptions};
-
+use lexical_parse_float::{FromLexicalWithOptions, format as lexical_format, Options as ParseFloatOptions};
 use crate::errors::{json_err, JsonResult};
 
 pub trait AbstractNumberDecoder {
@@ -82,7 +81,7 @@ impl AbstractNumberDecoder for NumberFloat {
             Some(digit) if digit.is_ascii_digit() => {
                 const JSON: u128 = lexical_format::JSON;
                 let options = ParseFloatOptions::new();
-                match parse_partial_with_options::<f64, JSON>(&data[start..], &options) {
+                match f64::from_lexical_partial_with_options::<JSON>(&data[start..], &options) {
                     Ok((float, index)) => Ok((float, index + start)),
                     Err(_) => {
                         // it's impossible to work out the right error from LexicalError here, so we parse again


### PR DESCRIPTION
Closes #49.

Code changes are minimal - I have adjusted the `use` statement to import things under the same names as previously, and only one line of actual code needs to be changed - the `parse_partial_with_options` function is from `lexical-core`, but it is a trivial one-line function, so it can just be replaced with calling the trait method on f64 directly.