### PR TITLE
Parse big ints using `PyLong_FromString` instead of `BigInt`

### DIFF
--- a/benches/python.rs
+++ b/benches/python.rs
@@ -55,6 +55,10 @@ fn _python_parse_file(path: &str, bench: &mut Bencher, cache_strings: bool) {
     })
 }
 
+fn python_parse_massive_ints_array(bench: &mut Bencher) {
+    _python_parse_file("./benches/massive_ints_array.json", bench, true);
+}
+
 fn python_parse_medium_response_not_cached(bench: &mut Bencher) {
     _python_parse_file("./benches/medium_response.json", bench, false);
 }
@@ -115,5 +119,6 @@ benchmark_group!(
     python_parse_x100,
     python_parse_true_object,
     python_parse_true_array,
+    python_parse_massive_ints_array,
 );
 benchmark_main!(benches);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -182,7 +182,7 @@ impl<'j> Parser<'j> {
         Ok(output)
     }
 
-    pub fn consume_number<D: AbstractNumberDecoder>(
+    pub fn consume_number<D: AbstractNumberDecoder<'j>>(
         &mut self,
         first: u8,
         allow_inf_nan: bool,


### PR DESCRIPTION
Seems to be a little bit slower, I thought this might be faster as it's [what `ujson` does](https://github.com/ultrajson/ultrajson/blob/0d2d8c5450db4fa5586072d37846ed3f92135f4a/python/JSONtoObj.c#L139).

@davidhewitt any thoughts? Most of the time seems to be in `PyLong_FromString`, flamegraph [here](https://share.firefox.dev/3tZYdmz).