### PR TITLE
use simdutf8 for string validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ smallvec = "1.11.0"
 pyo3 = { version = "0.20.0", features = ["num-bigint"], optional = true }
 lexical-core = { version = "0.8.5", features = ["format"] }
 hashbrown = "0.14.3"
+simdutf8 = { version = "0.1.4", features = ["aarch64_neon"] }
 
 [features]
 python = ["dep:pyo3"]

--- a/src/string_decoder.rs
+++ b/src/string_decoder.rs
@@ -1,5 +1,7 @@
 use std::ops::Range;
-use std::str::{from_utf8, from_utf8_unchecked};
+use std::str::from_utf8_unchecked;
+
+use simdutf8::compat::from_utf8;
 
 use crate::errors::{json_err, json_error, JsonResult};
 


### PR DESCRIPTION
doesn't seem to be any faster on M1, but we should check codspeed and x86.