### PR TITLE
chore(bench): update CodSpeed/action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
 
     - run: cargo codspeed build -F python -p jiter
 
-    - uses: CodSpeedHQ/action@v1
+    - uses: CodSpeedHQ/action@v2
       with:
         run: cargo codspeed run
         token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
Upgrading to the v2 of https://github.com/CodSpeedHQ/action will bring a better base run selection algorithm, better logging, and continued support.