### PR TITLE
convert skip to iterate instead of call recursive functions

### DIFF
--- a/crates/jiter/Cargo.toml
+++ b/crates/jiter/Cargo.toml
@@ -18,6 +18,7 @@ ahash = "0.8.0"
 smallvec = "1.11.0"
 pyo3 = { version = "0.21.0", optional = true }
 lexical-parse-float = { version = "0.8.5", features =  ["format"] }
+bitvec = "1.0.1"
 
 [features]
 python = ["dep:pyo3", "dep:pyo3-build-config"]


### PR DESCRIPTION
The observation is that "skip" functionality shouldn't be hard to avoid function recursion because the return type is always `()`. So here's an attempted implementation. Should hopefully be faster...