### PR TITLE
feat: Make num-bigint optional

### DIFF
--- a/crates/jiter-python/Cargo.toml
+++ b/crates/jiter-python/Cargo.toml
@@ -11,7 +11,7 @@ repository = {workspace = true}
 
 [dependencies]
 pyo3 = { workspace = true, features = ["num-bigint"] }
-jiter = { path = "../jiter", features = ["python"] }
+jiter = { path = "../jiter", features = ["python", "num-bigint"] }
 
 [features]
 # must be enabled when building with `cargo build`, maturin enables this automatically

--- a/crates/jiter/Cargo.toml
+++ b/crates/jiter/Cargo.toml
@@ -2,31 +2,37 @@
 name = "jiter"
 description = "Fast Iterable JSON parser"
 readme = "../../README.md"
-version = {workspace = true}
-edition = {workspace = true}
-authors = {workspace = true}
-license = {workspace = true}
-keywords = {workspace = true}
-categories = {workspace = true}
-homepage = {workspace = true}
-repository = {workspace = true}
+version = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
-num-bigint = "0.4.4"
+num-bigint = { version = "0.4.4", optional = true }
 num-traits = "0.2.16"
 ahash = "0.8.0"
 smallvec = "1.11.0"
-pyo3 = { workspace = true, optional = true, features = ["num-bigint"] }
-lexical-parse-float = { version = "0.8.5", features =  ["format"] }
+pyo3 = { workspace = true, optional = true }
+lexical-parse-float = { version = "0.8.5", features = ["format"] }
 bitvec = "1.0.1"
 
 [features]
+default = ["num-bigint"]
 python = ["dep:pyo3", "dep:pyo3-build-config"]
+num-bigint = ["dep:num-bigint", "pyo3/num-bigint"]
 
 [dev-dependencies]
 bencher = "0.1.5"
 paste = "1.0.7"
-serde_json = {version = "1.0.87", features = ["preserve_order", "arbitrary_precision", "float_roundtrip"]}
+serde_json = { version = "1.0.87", features = [
+    "preserve_order",
+    "arbitrary_precision",
+    "float_roundtrip",
+] }
 serde = "1.0.147"
 pyo3 = { workspace = true, features = ["auto-initialize"] }
 codspeed-bencher-compat = "2.7.1"
@@ -71,5 +77,5 @@ doc_markdown = "allow"
 implicit_clone = "allow"
 iter_without_into_iter = "allow"
 return_self_not_must_use = "allow"
-inline_always = "allow"  # TODO remove?
-match_same_arms = "allow"  # TODO remove?
+inline_always = "allow"                      # TODO remove?
+match_same_arms = "allow"                    # TODO remove?

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+#[cfg(feature = "num-bigint")]
 use num_bigint::BigInt;
 use smallvec::SmallVec;
 
@@ -16,6 +17,7 @@ pub enum JsonValue<'s> {
     Null,
     Bool(bool),
     Int(i64),
+    #[cfg(feature = "num-bigint")]
     BigInt(BigInt),
     Float(f64),
     Str(Cow<'s, str>),
@@ -34,6 +36,7 @@ impl pyo3::ToPyObject for JsonValue<'_> {
             Self::Null => py.None().to_object(py),
             Self::Bool(b) => b.to_object(py),
             Self::Int(i) => i.to_object(py),
+            #[cfg(feature = "num-bigint")]
             Self::BigInt(b) => b.to_object(py),
             Self::Float(f) => f.to_object(py),
             Self::Str(s) => s.to_object(py),
@@ -78,6 +81,7 @@ fn value_static(v: JsonValue<'_>) -> JsonValue<'static> {
         JsonValue::Null => JsonValue::Null,
         JsonValue::Bool(b) => JsonValue::Bool(b),
         JsonValue::Int(i) => JsonValue::Int(i),
+        #[cfg(feature = "num-bigint")]
         JsonValue::BigInt(b) => JsonValue::BigInt(b),
         JsonValue::Float(f) => JsonValue::Float(f),
         JsonValue::Str(s) => JsonValue::Str(s.into_owned().into()),
@@ -214,6 +218,7 @@ fn take_value<'j, 's>(
             let n = parser.consume_number::<NumberAny>(peek.into_inner(), allow_inf_nan);
             match n {
                 Ok(NumberAny::Int(NumberInt::Int(int))) => Ok(JsonValue::Int(int)),
+                #[cfg(feature = "num-bigint")]
                 Ok(NumberAny::Int(NumberInt::BigInt(big_int))) => Ok(JsonValue::BigInt(big_int)),
                 Ok(NumberAny::Float(float)) => Ok(JsonValue::Float(float)),
                 Err(e) => {


### PR DESCRIPTION
Closes #124 

Apologies for the few TOML reformats that slipped through, I can get rid of those if needed.

A few statics got turned into consts and moved inline with the BigInt code to avoid "unused variable" warnings.

I would recommend running `cargo hack --feature-powerset check` in CI, from https://lib.rs/crates/cargo-hack

---

A "default features build" (with num-bigint) is 4.7s at best for me:

![CleanShot 2024-08-16 at 17 40 21@2x](https://github.com/user-attachments/assets/757aa7d1-61e9-4aa1-a74e-d3c95dcfcfc1)

Command used:

```shell
cargo clean ; cargo build --package jiter --quiet --timings && w3m -dump target/*timings/*timing.html | grep 'Total time.*$' --color=always -B3
```

And a "no default features" build is just under two seconds:

![CleanShot 2024-08-16 at 17 41 36@2x](https://github.com/user-attachments/assets/7f3e37bc-ead5-442b-8d25-67338b402b51)

Command used:

```shell
cargo clean ; cargo build --package jiter --quiet --timings --no-default-features && w3m -dump target/*timings/*timing.html | grep 'Total time.*$' --color=always -B3
```