### PR TITLE
Fix no-bigint build failures, check those in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
     types: [rust]
     language: system
     pass_filenames: false
+  - id: check-without-num-bigint
+    name: Check without num-bigint feature
+    entry: cargo check --no-default-features --package jiter
+    types: [rust]
+    language: system
+    pass_filenames: false
   - id: test
     name: Test
     entry: cargo test --test main

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -309,6 +309,7 @@ fn take_value_recursive<'j, 's>(
                                 })?;
                             match n {
                                 NumberAny::Int(NumberInt::Int(int)) => JsonValue::Int(int),
+                                #[cfg(feature = "num-bigint")]
                                 NumberAny::Int(NumberInt::BigInt(big_int)) => JsonValue::BigInt(big_int),
                                 NumberAny::Float(float) => JsonValue::Float(float),
                             }
@@ -386,6 +387,7 @@ fn take_value_recursive<'j, 's>(
                                 })?;
                             match n {
                                 NumberAny::Int(NumberInt::Int(int)) => JsonValue::Int(int),
+                                #[cfg(feature = "num-bigint")]
                                 NumberAny::Int(NumberInt::BigInt(big_int)) => JsonValue::BigInt(big_int),
                                 NumberAny::Float(float) => JsonValue::Float(float),
                             }


### PR DESCRIPTION
I forgot to fix a couple lines in the last PR — now they're checked by pre-commit, before committing (I'm assuming?) and in CI.