### PR TITLE
Fix `cargo vendor` of jiter crates

### DIFF
--- a/crates/jiter-python/Cargo.toml
+++ b/crates/jiter-python/Cargo.toml
@@ -13,6 +13,10 @@ repository = {workspace = true}
 pyo3 = { workspace = true, features = ["num-bigint"] }
 jiter = { path = "../jiter", features = ["python", "num-bigint"] }
 
+[features]
+# make extensions visible to cargo vendor
+extension-module = ["pyo3/extension-module", "pyo3/generate-import-lib"]
+
 [lib]
 name = "jiter_python"
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
Declare all extension module features in `Cargo.toml`, so they are visible to `cargo vendor`. Otherwise vendoring does not include additional dependencies like `python3-dll-a` and offline build fails.

Fixes: #148