### PR TITLE
Fix `pyo3` as an optional dependency

### DIFF
--- a/crates/jiter/Cargo.toml
+++ b/crates/jiter/Cargo.toml
@@ -23,7 +23,7 @@ bitvec = "1.0.1"
 [features]
 default = ["num-bigint"]
 python = ["dep:pyo3", "dep:pyo3-build-config"]
-num-bigint = ["dep:num-bigint", "pyo3/num-bigint"]
+num-bigint = ["dep:num-bigint", "pyo3?/num-bigint"]
 
 [dev-dependencies]
 bencher = "0.1.5"


### PR DESCRIPTION
This is a really small change, but currently if you are compiling `jiter` with default features, it will always bring in pyo3 to compile as well.  With this syntax, it will prevent the `num-bigint` feature from pulling in pyo3.