### PR TITLE
ci: use Python 3.13 for Rust benches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
       - uses: moonrepo/setup-rust@v1
         with:
           channel: stable
@@ -139,7 +143,7 @@ jobs:
 
       - run: cargo codspeed build -F python -p jiter
 
-      - uses: CodSpeedHQ/action@v2
+      - uses: CodSpeedHQ/action@v3
         with:
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
Trivial cleanup; will merge as long as CI green.