### PR TITLE
Fix tests without num-bigint feature

### DIFF
--- a/crates/jiter/tests/python.rs
+++ b/crates/jiter/tests/python.rs
@@ -3,6 +3,7 @@ use pyo3::types::PyString;
 
 use jiter::{pystring_fast_new, JsonValue, PythonParse, StringCacheMode};
 
+#[cfg(feature = "num-bigint")]
 #[test]
 fn test_to_py_object_numeric() {
     let value = JsonValue::parse(


### PR DESCRIPTION
`cargo test --no-default-features` and `cargo test --no-default-features -F python` failed due to various tests that required the `num-bigint` feature.  Annotate these appropriately.