### PR TITLE
skip Windows free-threaded wheel build for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,10 @@ jobs:
             interpreter: "3.8"
           - os: macos
             interpreter: "3.9"
+          # windows free-threaded build has a problematic wheel name,
+          # needs something like https://github.com/PyO3/maturin/pull/2325 to fix
+          - os: windows
+            interpreter: "3.13t"
 
     runs-on: ${{ matrix.runs-on }}
     steps:


### PR DESCRIPTION
Skip building the Windows free-threaded wheel for the moment, so that we can ship 0.8.