### PR TITLE
Update to a current version of lexical-parse-float

### DIFF
--- a/crates/jiter/Cargo.toml
+++ b/crates/jiter/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = "0.2.16"
 ahash = "0.8.0"
 smallvec = "1.11.0"
 pyo3 = { workspace = true, optional = true }
-lexical-parse-float = { version = "0.8.5", features = ["format"] }
+lexical-parse-float = { version = "1.0.5", features = ["format"] }
 bitvec = "1.0.1"
 
 [features]


### PR DESCRIPTION
See https://github.com/Alexhuszagh/rust-lexical/blob/v1.0.5/CHANGELOG. The 1.0 release series of `rust-lexical` contains some significant fixes – although I haven’t investigated whether any of them affect the APIs used in jiter.

I confirmed that `cargo test --workspace` still passes.