### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-pyo3 = { version = "0.24" }
+pyo3 = { version = "0.24.1" }
 pyo3-build-config = { version = "0.24" }


### PR DESCRIPTION
Bumps the dependency to at least 0.24.1 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2025-0020.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)