### PR TITLE
skip shipping windows 3.14 wheels for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,7 @@ jobs:
             target: x86_64
           - os: macos
             target: aarch64
-            interpreter: '3.9'
+            interpreter: "3.9"
 
           # windows;
           # aarch64 only 3.11 and up, also not PGO optimized
@@ -346,7 +346,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [linux, windows, macos]
-        interpreter: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
+        interpreter:
+          ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
         include:
           # standard runners with override for macos arm
           - os: linux
@@ -360,6 +361,12 @@ jobs:
           # macos arm only supported from 3.10 and up
           - os: macos
             interpreter: "3.9"
+          # windows 3.14 cffi install blocks build on 3.14 beta 1
+          # https://github.com/python/cpython/issues/133779
+          - os: windows
+            interpreter: "3.14"
+          - os: windows
+            interpreter: "3.14t"
 
     runs-on: ${{ matrix.runs-on }}
     steps:


### PR DESCRIPTION
To workaround https://github.com/python/cpython/issues/133779 (breaks `cffi` build)