### PR TITLE
replace `cached_py_string` and `pystring_fast_new` with safe alternatives

### DIFF
--- a/crates/jiter/src/lib.rs
+++ b/crates/jiter/src/lib.rs
@@ -172,7 +172,9 @@ pub use value::{JsonArray, JsonObject, JsonValue};
 #[cfg(feature = "python")]
 pub use py_lossless_float::{FloatMode, LosslessFloat};
 #[cfg(feature = "python")]
-pub use py_string_cache::{cache_clear, cache_usage, cached_py_string, pystring_fast_new, StringCacheMode};
+pub use py_string_cache::{
+    cache_clear, cache_usage, cached_py_string, cached_py_string_ascii, pystring_ascii_new, StringCacheMode,
+};
 #[cfg(feature = "python")]
 pub use python::{map_json_error, PythonParse};
 

--- a/crates/jiter/src/python.rs
+++ b/crates/jiter/src/python.rs
@@ -138,7 +138,7 @@ impl<StringCache: StringMaybeCache, KeyCheck: MaybeKeyCheck, ParseNumber: MaybeP
                 let s = self
                     .parser
                     .consume_string::<StringDecoder>(&mut self.tape, self.partial_mode.allow_trailing_str())?;
-                Ok(StringCache::get_value(py, s.as_str(), s.ascii_only()).into_any())
+                Ok(StringCache::get_value(py, s).into_any())
             }
             Peek::Array => {
                 let peek_first = match self.parser.array_first() {
@@ -198,14 +198,14 @@ impl<StringCache: StringMaybeCache, KeyCheck: MaybeKeyCheck, ParseNumber: MaybeP
         if let Some(first_key) = self.parser.object_first::<StringDecoder>(&mut self.tape)? {
             let first_key_s = first_key.as_str();
             check_keys.check(first_key_s, self.parser.index)?;
-            let first_key = StringCache::get_key(py, first_key_s, first_key.ascii_only());
+            let first_key = StringCache::get_key(py, first_key);
             let peek = self.parser.peek()?;
             let first_value = self.check_take_value(py, peek)?;
             set_item(first_key, first_value);
             while let Some(key) = self.parser.object_step::<StringDecoder>(&mut self.tape)? {
                 let key_s = key.as_str();
                 check_keys.check(key_s, self.parser.index)?;
-                let key = StringCache::get_key(py, key_s, key.ascii_only());
+                let key = StringCache::get_key(py, key);
                 let peek = self.parser.peek()?;
                 let value = self.check_take_value(py, peek)?;
                 set_item(key, value);

--- a/crates/jiter/tests/python.rs
+++ b/crates/jiter/tests/python.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 
-use jiter::{pystring_fast_new, JsonValue, PythonParse, StringCacheMode};
+use jiter::{pystring_ascii_new, JsonValue, PythonParse, StringCacheMode};
 
 #[cfg(feature = "num-bigint")]
 #[test]
@@ -71,19 +71,10 @@ fn test_cache_into() {
 }
 
 #[test]
-fn test_pystring_fast_new_non_ascii() {
-    let json = "£100 💩";
-    Python::with_gil(|py| {
-        let s = pystring_fast_new(py, json, false);
-        assert_eq!(s.to_string(), "£100 💩");
-    });
-}
-
-#[test]
-fn test_pystring_fast_new_ascii() {
+fn test_pystring_ascii_new() {
     let json = "100abc";
     Python::with_gil(|py| {
-        let s = pystring_fast_new(py, json, true);
+        let s = unsafe { pystring_ascii_new(py, json) };
         assert_eq!(s.to_string(), "100abc");
     });
 }


### PR DESCRIPTION
Closes #177 

This PR:
  - removes `ascii_only` flag from `cached_py_string` to make it safe to call
  - adds unsafe function `cached_py_string_ascii` which has the ascii optimization
  - replaces `pystring_fast_new` with an unsafe function `pystring_new_ascii`

To make the implementation correctly uphold invariants I had to move around the logic a bit, particularly making the `StringOutput` type carry the information about `ascii_only`.