### PR TITLE
ci: fix ability of job to upload wasm wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -614,6 +614,8 @@ jobs:
     environment: release-python
     permissions:
       id-token: write
+      # needed to be able to upload wasm wheels
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Should fix issue with the wasm wheel upload on release jobs.

Will send 0.10 after merging this.