### PR TITLE
Impl `std::error::Error` for error types

### DIFF
--- a/crates/jiter/src/errors.rs
+++ b/crates/jiter/src/errors.rs
@@ -155,6 +155,8 @@ impl std::fmt::Display for JsonError {
     }
 }
 
+impl std::error::Error for JsonError {}
+
 macro_rules! json_error {
     ($error_type:ident, $index:expr) => {
         crate::errors::JsonError::new(crate::errors::JsonErrorType::$error_type, $index)
@@ -230,6 +232,8 @@ impl std::fmt::Display for JiterError {
         write!(f, "{} at index {}", self.error_type, self.index)
     }
 }
+
+impl std::error::Error for JiterError {}
 
 impl JiterError {
     pub(crate) fn new(error_type: JiterErrorType, index: usize) -> Self {


### PR DESCRIPTION
This commit updates the library error types to implement `std::error::Error`.

Currently, `JiterError` and `JsonError` do not implement `std::error::Error`. This prevents error chaining and interoperability with standard error handling.

```rs
use jiter::JsonValue;

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let json_data = r#"
        {
            "name": "John Doe",
            "age": 43,
            "phones": [
                "+44 1234567",
                "+44 2345678"
            ]
        }"#;
    let json_value = JsonValue::parse(json_data.as_bytes(), true)?; // <-- can't do this
    println!("{:#?}", json_value);

    Ok(())
}
```