### PR TITLE
allow `python_parse` to take ref to self

### DIFF
--- a/crates/jiter/src/python.rs
+++ b/crates/jiter/src/python.rs
@@ -44,7 +44,7 @@ impl PythonParse {
     /// # Returns
     ///
     /// A [PyObject](https://docs.rs/pyo3/latest/pyo3/type.PyObject.html) representing the parsed JSON value.
-    pub fn python_parse<'py>(self, py: Python<'py>, json_data: &[u8]) -> JsonResult<Bound<'py, PyAny>> {
+    pub fn python_parse<'py>(&self, py: Python<'py>, json_data: &[u8]) -> JsonResult<Bound<'py, PyAny>> {
         macro_rules! ppp {
             ($string_cache:ident, $key_check:ident, $parse_number:ident) => {
                 PythonParser::<$string_cache, $key_check, $parse_number>::parse(


### PR DESCRIPTION
By taking a ref to self, one (moi) does not have to create a new `PythonParse` instance if parsing a group o lines. 

It might be nice to expose the actual parsers? 

Lmk if this is bad!