### PR TITLE
Fix linux-x86_64 build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
           - os: linux
             manylinux: auto
             target: x86_64
-            interpreter: 3.9 3.10 3.11 3.12 3.13 3.14 graalpy3.11
+            interpreter: graalpy3.11
           - os: linux
             manylinux: auto
             target: i686


### PR DESCRIPTION
Hi @davidhewitt, I think I misunderstood the CI matrix in my last PR (#212). I didn't notice there was an exclusion rule for linux-x86_64 builds (in favor of the pgo jobs). So the non-pgo job should build just GraalPy to avoid duplication.