### PR TITLE
refactor: convert all `downcast`s to `cast`s

### DIFF
--- a/crates/jiter/src/py_string_cache.rs
+++ b/crates/jiter/src/py_string_cache.rs
@@ -22,7 +22,7 @@ impl Default for StringCacheMode {
 
 impl<'py> FromPyObject<'py> for StringCacheMode {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<StringCacheMode> {
-        if let Ok(bool_mode) = ob.downcast::<PyBool>() {
+        if let Ok(bool_mode) = ob.cast::<PyBool>() {
             Ok(bool_mode.is_true().into())
         } else if let Ok(str_mode) = ob.extract::<&str>() {
             match str_mode {
@@ -258,7 +258,7 @@ pub unsafe fn pystring_ascii_new<'py>(py: Python<'py>, s: &str) -> Bound<'py, Py
         let data_ptr = pyo3::ffi::PyUnicode_DATA(ptr).cast();
         core::ptr::copy_nonoverlapping(s.as_ptr(), data_ptr, s.len());
         core::ptr::write(data_ptr.add(s.len()), 0);
-        Bound::from_owned_ptr(py, ptr).downcast_into_unchecked()
+        Bound::from_owned_ptr(py, ptr).cast_into_unchecked()
     }
 
     #[cfg(any(PyPy, GraalPy, Py_LIMITED_API))]

--- a/crates/jiter/src/python.rs
+++ b/crates/jiter/src/python.rs
@@ -239,7 +239,7 @@ const PARTIAL_ERROR: &str = "Invalid partial mode, should be `'off'`, `'on'`, `'
 
 impl<'py> FromPyObject<'py> for PartialMode {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        if let Ok(bool_mode) = ob.downcast::<PyBool>() {
+        if let Ok(bool_mode) = ob.cast::<PyBool>() {
             Ok(bool_mode.is_true().into())
         } else if let Ok(str_mode) = ob.extract::<&str>() {
             match str_mode {


### PR DESCRIPTION
Ran this: `rg downcast -l | xargs -n1 -t sed -i 's/downcast/cast/g'`

@davidhewitt are all the variations of `downcast[_*` et-al being replaced with `cast`?
