### PR TITLE
expose `known_number_bytes` and parser methods for bytes -> number

### DIFF
--- a/crates/jiter/src/jiter.rs
+++ b/crates/jiter/src/jiter.rs
@@ -168,6 +168,7 @@ impl<'j> Jiter<'j> {
     pub fn known_float(&mut self, peek: Peek) -> JiterResult<f64> {
         self.parser
             .consume_number::<NumberFloat>(peek.into_inner(), self.allow_inf_nan)
+            .map(|f| f.0)
             .map_err(|e| self.maybe_number_error(e, JsonType::Float, peek))
     }
 

--- a/crates/jiter/src/jiter.rs
+++ b/crates/jiter/src/jiter.rs
@@ -178,7 +178,7 @@ impl<'j> Jiter<'j> {
     }
 
     /// Knowing the next value is a number, parse it and return bytes from the original JSON data.
-    fn known_number_bytes(&mut self, peek: Peek) -> JiterResult<&[u8]> {
+    pub fn known_number_bytes(&mut self, peek: Peek) -> JiterResult<&[u8]> {
         match self
             .parser
             .consume_number::<NumberRange>(peek.into_inner(), self.allow_inf_nan)

--- a/crates/jiter/src/lib.rs
+++ b/crates/jiter/src/lib.rs
@@ -165,7 +165,7 @@ mod value;
 
 pub use errors::{JiterError, JiterErrorType, JsonError, JsonErrorType, JsonResult, JsonType, LinePosition};
 pub use jiter::{Jiter, JiterResult};
-pub use number_decoder::{NumberAny, NumberInt, parse_float_bytes, parse_int_bytes, parse_number_bytes};
+pub use number_decoder::{NumberAny, NumberFloat, NumberInt};
 pub use parse::Peek;
 pub use value::{JsonArray, JsonObject, JsonValue};
 

--- a/crates/jiter/src/lib.rs
+++ b/crates/jiter/src/lib.rs
@@ -165,7 +165,7 @@ mod value;
 
 pub use errors::{JiterError, JiterErrorType, JsonError, JsonErrorType, JsonResult, JsonType, LinePosition};
 pub use jiter::{Jiter, JiterResult};
-pub use number_decoder::{NumberAny, NumberInt};
+pub use number_decoder::{NumberAny, NumberInt, parse_float_bytes, parse_int_bytes, parse_number_bytes};
 pub use parse::Peek;
 pub use value::{JsonArray, JsonObject, JsonValue};
 

--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -40,18 +40,37 @@ impl TryFrom<&[u8]> for NumberInt {
     type Error = JsonError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let first = *value.first().ok_or_else(|| json_error!(InvalidNumber, 0))?;
-        let (int_parse, index) = IntParse::parse(value, 0, first)?;
-        match int_parse {
-            IntParse::Int(int) => {
-                if index == value.len() {
-                    Ok(int)
-                } else {
-                    json_err!(InvalidNumber, index)
-                }
-            }
-            _ => json_err!(InvalidNumber, index),
-        }
+        parse_int_bytes(value)
+    }
+}
+
+/// Parse `data` as a JSON number, erroring if the input is empty or contains trailing bytes.
+pub fn parse_number_bytes(data: &[u8], allow_inf_nan: bool) -> JsonResult<NumberAny> {
+    parse_complete::<NumberAny>(data, allow_inf_nan)
+}
+
+/// Parse `data` as a JSON integer, erroring if the input is not a valid integer, is empty, or contains trailing bytes.
+pub fn parse_int_bytes(data: &[u8]) -> JsonResult<NumberInt> {
+    let first = *data.first().ok_or_else(|| json_error!(InvalidNumber, 0))?;
+    let (int_parse, index) = IntParse::parse(data, 0, first)?;
+    match int_parse {
+        IntParse::Int(int) if index == data.len() => Ok(int),
+        _ => json_err!(InvalidNumber, index),
+    }
+}
+
+/// Parse `data` as a JSON float, erroring if the input is empty or contains trailing bytes.
+pub fn parse_float_bytes(data: &[u8], allow_inf_nan: bool) -> JsonResult<f64> {
+    parse_complete::<NumberFloat>(data, allow_inf_nan)
+}
+
+fn parse_complete<D: AbstractNumberDecoder>(data: &[u8], allow_inf_nan: bool) -> JsonResult<D::Output> {
+    let first = *data.first().ok_or_else(|| json_error!(InvalidNumber, 0))?;
+    let (output, index) = D::decode(data, 0, first, allow_inf_nan)?;
+    if index == data.len() {
+        Ok(output)
+    } else {
+        json_err!(InvalidNumber, index)
     }
 }
 

--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -11,10 +11,8 @@ use lexical_parse_float::{FromLexicalWithOptions, Options as ParseFloatOptions, 
 
 use crate::errors::{JsonError, JsonResult, json_err, json_error};
 
-pub trait AbstractNumberDecoder {
-    type Output;
-
-    fn decode(data: &[u8], index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self::Output, usize)>;
+pub trait AbstractNumberDecoder: Sized {
+    fn decode(data: &[u8], index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)>;
 }
 
 /// A number that can be either an [i64] or a [BigInt](num_bigint::BigInt)
@@ -40,44 +38,25 @@ impl TryFrom<&[u8]> for NumberInt {
     type Error = JsonError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        parse_int_bytes(value)
+        Self::from_bytes(value)
     }
 }
 
-/// Parse `data` as a JSON number, erroring if the input is empty or contains trailing bytes.
-pub fn parse_number_bytes(data: &[u8], allow_inf_nan: bool) -> JsonResult<NumberAny> {
-    parse_complete::<NumberAny>(data, allow_inf_nan)
-}
-
-/// Parse `data` as a JSON integer, erroring if the input is not a valid integer, is empty, or contains trailing bytes.
-pub fn parse_int_bytes(data: &[u8]) -> JsonResult<NumberInt> {
-    let first = *data.first().ok_or_else(|| json_error!(InvalidNumber, 0))?;
-    let (int_parse, index) = IntParse::parse(data, 0, first)?;
-    match int_parse {
-        IntParse::Int(int) if index == data.len() => Ok(int),
-        _ => json_err!(InvalidNumber, index),
-    }
-}
-
-/// Parse `data` as a JSON float, erroring if the input is empty or contains trailing bytes.
-pub fn parse_float_bytes(data: &[u8], allow_inf_nan: bool) -> JsonResult<f64> {
-    parse_complete::<NumberFloat>(data, allow_inf_nan)
-}
-
-fn parse_complete<D: AbstractNumberDecoder>(data: &[u8], allow_inf_nan: bool) -> JsonResult<D::Output> {
-    let first = *data.first().ok_or_else(|| json_error!(InvalidNumber, 0))?;
-    let (output, index) = D::decode(data, 0, first, allow_inf_nan)?;
-    if index == data.len() {
-        Ok(output)
-    } else {
-        json_err!(InvalidNumber, index)
+impl NumberInt {
+    /// Parse `data` as a JSON integer, erroring if the input is not a valid integer,
+    /// is empty, or contains trailing bytes.
+    pub fn from_bytes(data: &[u8]) -> JsonResult<Self> {
+        let first = *data.first().ok_or_else(|| json_error!(InvalidNumber, 0))?;
+        let (int_parse, index) = IntParse::parse(data, 0, first)?;
+        match int_parse {
+            IntParse::Int(int) if index == data.len() => Ok(int),
+            _ => json_err!(InvalidNumber, index),
+        }
     }
 }
 
 impl AbstractNumberDecoder for NumberInt {
-    type Output = NumberInt;
-
-    fn decode(data: &[u8], index: usize, first: u8, _allow_inf_nan: bool) -> JsonResult<(Self::Output, usize)> {
+    fn decode(data: &[u8], index: usize, first: u8, _allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
         let (int_parse, index) = IntParse::parse(data, index, first)?;
         match int_parse {
             IntParse::Int(int) => Ok((int, index)),
@@ -86,16 +65,31 @@ impl AbstractNumberDecoder for NumberInt {
     }
 }
 
-pub struct NumberFloat;
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NumberFloat(pub f64);
+
+impl From<NumberFloat> for f64 {
+    fn from(num: NumberFloat) -> Self {
+        num.0
+    }
+}
+
+impl NumberFloat {
+    /// Parse `data` as a JSON float, erroring if the input is empty or contains trailing bytes.
+    pub fn from_bytes(data: &[u8], allow_inf_nan: bool) -> JsonResult<Self> {
+        from_bytes_complete(data, allow_inf_nan)
+    }
+}
 
 impl AbstractNumberDecoder for NumberFloat {
-    type Output = f64;
-
-    fn decode(data: &[u8], mut index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self::Output, usize)> {
+    fn decode(data: &[u8], mut index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
         let start = index;
 
         let positive = match first {
-            b'N' => return consume_nan(data, index, allow_inf_nan),
+            b'N' => {
+                let (f, end) = consume_nan(data, index, allow_inf_nan)?;
+                return Ok((Self(f), end));
+            }
             b'-' => false,
             _ => true,
         };
@@ -110,7 +104,7 @@ impl AbstractNumberDecoder for NumberFloat {
                 const JSON: u128 = lexical_format::JSON;
                 let options = ParseFloatOptions::new();
                 match f64::from_lexical_partial_with_options::<JSON>(&data[start..], &options) {
-                    Ok((float, index)) => Ok((float, index + start)),
+                    Ok((float, index)) => Ok((Self(float), index + start)),
                     Err(_) => {
                         // it's impossible to work out the right error from LexicalError here, so we parse again
                         // with NumberRange and use that error
@@ -123,7 +117,8 @@ impl AbstractNumberDecoder for NumberFloat {
                     }
                 }
             } else if digit == &b'I' {
-                consume_inf_f64(data, index, positive, allow_inf_nan)
+                let (f, end) = consume_inf_f64(data, index, positive, allow_inf_nan)?;
+                Ok((Self(f), end))
             } else {
                 json_err!(InvalidNumber, index)
             }
@@ -150,22 +145,37 @@ impl From<NumberAny> for f64 {
     }
 }
 
-impl AbstractNumberDecoder for NumberAny {
-    type Output = NumberAny;
+impl NumberAny {
+    /// Parse `data` as a JSON number, erroring if the input is empty or contains trailing bytes.
+    pub fn from_bytes(data: &[u8], allow_inf_nan: bool) -> JsonResult<Self> {
+        from_bytes_complete(data, allow_inf_nan)
+    }
+}
 
-    fn decode(data: &[u8], index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self::Output, usize)> {
+impl AbstractNumberDecoder for NumberAny {
+    fn decode(data: &[u8], index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
         let start = index;
         let (int_parse, index) = IntParse::parse(data, index, first)?;
         match int_parse {
             IntParse::Int(int) => Ok((Self::Int(int), index)),
             IntParse::Float => {
-                NumberFloat::decode(data, start, first, allow_inf_nan).map(|(f, index)| (Self::Float(f), index))
+                NumberFloat::decode(data, start, first, allow_inf_nan).map(|(f, index)| (Self::Float(f.0), index))
             }
             IntParse::FloatInf(positive) => {
                 consume_inf_f64(data, index, positive, allow_inf_nan).map(|(f, index)| (Self::Float(f), index))
             }
             IntParse::FloatNaN => consume_nan(data, index, allow_inf_nan).map(|(f, index)| (Self::Float(f), index)),
         }
+    }
+}
+
+fn from_bytes_complete<D: AbstractNumberDecoder>(data: &[u8], allow_inf_nan: bool) -> JsonResult<D> {
+    let first = *data.first().ok_or_else(|| json_error!(InvalidNumber, 0))?;
+    let (output, index) = D::decode(data, 0, first, allow_inf_nan)?;
+    if index == data.len() {
+        Ok(output)
+    } else {
+        json_err!(InvalidNumber, index)
     }
 }
 
@@ -415,9 +425,7 @@ impl NumberRange {
 }
 
 impl AbstractNumberDecoder for NumberRange {
-    type Output = Self;
-
-    fn decode(data: &[u8], mut index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self::Output, usize)> {
+    fn decode(data: &[u8], mut index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
         let start = index;
 
         let positive = match first {

--- a/crates/jiter/src/parse.rs
+++ b/crates/jiter/src/parse.rs
@@ -209,11 +209,7 @@ impl<'j> Parser<'j> {
         Ok(output)
     }
 
-    pub fn consume_number<D: AbstractNumberDecoder>(
-        &mut self,
-        first: u8,
-        allow_inf_nan: bool,
-    ) -> JsonResult<D> {
+    pub fn consume_number<D: AbstractNumberDecoder>(&mut self, first: u8, allow_inf_nan: bool) -> JsonResult<D> {
         let (output, index) = D::decode(self.data, self.index, first, allow_inf_nan)?;
         self.index = index;
         Ok(output)

--- a/crates/jiter/src/parse.rs
+++ b/crates/jiter/src/parse.rs
@@ -213,7 +213,7 @@ impl<'j> Parser<'j> {
         &mut self,
         first: u8,
         allow_inf_nan: bool,
-    ) -> JsonResult<D::Output> {
+    ) -> JsonResult<D> {
         let (output, index) = D::decode(self.data, self.index, first, allow_inf_nan)?;
         self.index = index;
         Ok(output)

--- a/crates/jiter/tests/main.rs
+++ b/crates/jiter/tests/main.rs
@@ -1352,13 +1352,25 @@ fn test_number_int_try_from_bytes() {
 
 #[test]
 fn test_number_any_from_bytes() {
-    assert_eq!(NumberAny::from_bytes(b"123", false).unwrap(), NumberAny::Int(NumberInt::Int(123)));
-    assert_eq!(NumberAny::from_bytes(b"-123", false).unwrap(), NumberAny::Int(NumberInt::Int(-123)));
-    assert_eq!(NumberAny::from_bytes(b"0", false).unwrap(), NumberAny::Int(NumberInt::Int(0)));
+    assert_eq!(
+        NumberAny::from_bytes(b"123", false).unwrap(),
+        NumberAny::Int(NumberInt::Int(123))
+    );
+    assert_eq!(
+        NumberAny::from_bytes(b"-123", false).unwrap(),
+        NumberAny::Int(NumberInt::Int(-123))
+    );
+    assert_eq!(
+        NumberAny::from_bytes(b"0", false).unwrap(),
+        NumberAny::Int(NumberInt::Int(0))
+    );
     assert_eq!(NumberAny::from_bytes(b"1.5", false).unwrap(), NumberAny::Float(1.5));
     assert_eq!(NumberAny::from_bytes(b"-1.5", false).unwrap(), NumberAny::Float(-1.5));
     assert_eq!(NumberAny::from_bytes(b"1e3", false).unwrap(), NumberAny::Float(1e3));
-    assert_eq!(NumberAny::from_bytes(b"0.5e-2", false).unwrap(), NumberAny::Float(0.5e-2));
+    assert_eq!(
+        NumberAny::from_bytes(b"0.5e-2", false).unwrap(),
+        NumberAny::Float(0.5e-2)
+    );
 
     #[cfg(feature = "num-bigint")]
     {
@@ -1395,8 +1407,14 @@ fn test_number_any_from_bytes() {
         NumberAny::Float(f) => assert!(f.is_nan()),
         other @ NumberAny::Int(_) => panic!("expected NaN, got {other:?}"),
     }
-    assert_eq!(NumberAny::from_bytes(b"Infinity", true).unwrap(), NumberAny::Float(f64::INFINITY));
-    assert_eq!(NumberAny::from_bytes(b"-Infinity", true).unwrap(), NumberAny::Float(f64::NEG_INFINITY));
+    assert_eq!(
+        NumberAny::from_bytes(b"Infinity", true).unwrap(),
+        NumberAny::Float(f64::INFINITY)
+    );
+    assert_eq!(
+        NumberAny::from_bytes(b"-Infinity", true).unwrap(),
+        NumberAny::Float(f64::NEG_INFINITY)
+    );
 }
 
 #[test]
@@ -1428,8 +1446,14 @@ fn test_number_float_from_bytes() {
     assert_eq!(e.error_type, JsonErrorType::ExpectedSomeValue);
 
     assert!(NumberFloat::from_bytes(b"NaN", true).unwrap().0.is_nan());
-    assert_eq!(NumberFloat::from_bytes(b"Infinity", true).unwrap(), NumberFloat(f64::INFINITY));
-    assert_eq!(NumberFloat::from_bytes(b"-Infinity", true).unwrap(), NumberFloat(f64::NEG_INFINITY));
+    assert_eq!(
+        NumberFloat::from_bytes(b"Infinity", true).unwrap(),
+        NumberFloat(f64::INFINITY)
+    );
+    assert_eq!(
+        NumberFloat::from_bytes(b"-Infinity", true).unwrap(),
+        NumberFloat(f64::NEG_INFINITY)
+    );
 
     // From<NumberFloat> for f64
     let f: f64 = NumberFloat::from_bytes(b"2.5", false).unwrap().into();

--- a/crates/jiter/tests/main.rs
+++ b/crates/jiter/tests/main.rs
@@ -11,7 +11,7 @@ use num_bigint::BigInt;
 
 use jiter::{
     Jiter, JiterErrorType, JiterResult, JsonErrorType, JsonObject, JsonType, JsonValue, LinePosition, NumberAny,
-    NumberInt, PartialMode, Peek,
+    NumberFloat, NumberInt, PartialMode, Peek,
 };
 
 fn json_vec(jiter: &mut Jiter, peek: Option<Peek>) -> JiterResult<Vec<String>> {
@@ -1348,6 +1348,92 @@ fn test_number_int_try_from_bytes() {
         let e = NumberInt::try_from(too_long.as_bytes()).unwrap_err();
         assert_eq!(e.to_string(), "number out of range at index 4301");
     }
+}
+
+#[test]
+fn test_number_any_from_bytes() {
+    assert_eq!(NumberAny::from_bytes(b"123", false).unwrap(), NumberAny::Int(NumberInt::Int(123)));
+    assert_eq!(NumberAny::from_bytes(b"-123", false).unwrap(), NumberAny::Int(NumberInt::Int(-123)));
+    assert_eq!(NumberAny::from_bytes(b"0", false).unwrap(), NumberAny::Int(NumberInt::Int(0)));
+    assert_eq!(NumberAny::from_bytes(b"1.5", false).unwrap(), NumberAny::Float(1.5));
+    assert_eq!(NumberAny::from_bytes(b"-1.5", false).unwrap(), NumberAny::Float(-1.5));
+    assert_eq!(NumberAny::from_bytes(b"1e3", false).unwrap(), NumberAny::Float(1e3));
+    assert_eq!(NumberAny::from_bytes(b"0.5e-2", false).unwrap(), NumberAny::Float(0.5e-2));
+
+    #[cfg(feature = "num-bigint")]
+    {
+        let twenty_nines = "9".repeat(29);
+        let n = NumberAny::from_bytes(twenty_nines.as_bytes(), false).unwrap();
+        match n {
+            NumberAny::Int(NumberInt::BigInt(v)) => assert_eq!(v.to_string(), twenty_nines),
+            _ => panic!("expected big int"),
+        }
+    }
+
+    let e = NumberAny::from_bytes(b"", false).unwrap_err();
+    assert_eq!(e.to_string(), "invalid number at index 0");
+
+    let e = NumberAny::from_bytes(b"x23", false).unwrap_err();
+    assert_eq!(e.to_string(), "invalid number at index 0");
+
+    let e = NumberAny::from_bytes(b"123 ", false).unwrap_err();
+    assert_eq!(e.to_string(), "invalid number at index 3");
+
+    let e = NumberAny::from_bytes(b"1.5x", false).unwrap_err();
+    assert_eq!(e.to_string(), "invalid number at index 3");
+
+    let e = NumberAny::from_bytes(b"0123", false).unwrap_err();
+    assert_eq!(e.to_string(), "invalid number at index 1");
+
+    // allow_inf_nan toggles
+    let e = NumberAny::from_bytes(b"NaN", false).unwrap_err();
+    assert_eq!(e.error_type, JsonErrorType::ExpectedSomeValue);
+    let e = NumberAny::from_bytes(b"Infinity", false).unwrap_err();
+    assert_eq!(e.error_type, JsonErrorType::ExpectedSomeValue);
+
+    match NumberAny::from_bytes(b"NaN", true).unwrap() {
+        NumberAny::Float(f) => assert!(f.is_nan()),
+        other @ NumberAny::Int(_) => panic!("expected NaN, got {other:?}"),
+    }
+    assert_eq!(NumberAny::from_bytes(b"Infinity", true).unwrap(), NumberAny::Float(f64::INFINITY));
+    assert_eq!(NumberAny::from_bytes(b"-Infinity", true).unwrap(), NumberAny::Float(f64::NEG_INFINITY));
+}
+
+#[test]
+fn test_number_float_from_bytes() {
+    assert_eq!(NumberFloat::from_bytes(b"1.5", false).unwrap(), NumberFloat(1.5));
+    assert_eq!(NumberFloat::from_bytes(b"-1.5", false).unwrap(), NumberFloat(-1.5));
+    assert_eq!(NumberFloat::from_bytes(b"0", false).unwrap(), NumberFloat(0.0));
+    // integer-shaped input parses as float
+    assert_eq!(NumberFloat::from_bytes(b"42", false).unwrap(), NumberFloat(42.0));
+    assert_eq!(NumberFloat::from_bytes(b"1e3", false).unwrap(), NumberFloat(1e3));
+    assert_eq!(NumberFloat::from_bytes(b"1.5e-2", false).unwrap(), NumberFloat(1.5e-2));
+
+    let e = NumberFloat::from_bytes(b"", false).unwrap_err();
+    assert_eq!(e.to_string(), "invalid number at index 0");
+
+    let e = NumberFloat::from_bytes(b"x", false).unwrap_err();
+    assert_eq!(e.to_string(), "invalid number at index 0");
+
+    let e = NumberFloat::from_bytes(b"1.5 ", false).unwrap_err();
+    assert_eq!(e.to_string(), "invalid number at index 3");
+
+    let e = NumberFloat::from_bytes(b"1.5x", false).unwrap_err();
+    assert_eq!(e.to_string(), "invalid number at index 3");
+
+    // allow_inf_nan toggles
+    let e = NumberFloat::from_bytes(b"NaN", false).unwrap_err();
+    assert_eq!(e.error_type, JsonErrorType::ExpectedSomeValue);
+    let e = NumberFloat::from_bytes(b"Infinity", false).unwrap_err();
+    assert_eq!(e.error_type, JsonErrorType::ExpectedSomeValue);
+
+    assert!(NumberFloat::from_bytes(b"NaN", true).unwrap().0.is_nan());
+    assert_eq!(NumberFloat::from_bytes(b"Infinity", true).unwrap(), NumberFloat(f64::INFINITY));
+    assert_eq!(NumberFloat::from_bytes(b"-Infinity", true).unwrap(), NumberFloat(f64::NEG_INFINITY));
+
+    // From<NumberFloat> for f64
+    let f: f64 = NumberFloat::from_bytes(b"2.5", false).unwrap().into();
+    assert_eq!(f, 2.5);
 }
 
 #[test]


### PR DESCRIPTION
This exposes `known_number_bytes`, which matches `known_float`, `known_str` signatures etc, so should not be controversial.

I also exposed three helper methods to parse the subsequent byte range.