### PR TITLE
Add lossless JsonValue float mode

### DIFF
--- a/crates/jiter/src/jiter.rs
+++ b/crates/jiter/src/jiter.rs
@@ -2,7 +2,7 @@ use crate::errors::{DEFAULT_RECURSION_LIMIT, JiterError, JsonType, LinePosition,
 use crate::number_decoder::{NumberAny, NumberFloat, NumberInt, NumberRange};
 use crate::parse::{Parser, Peek};
 use crate::string_decoder::{StringDecoder, StringDecoderRange, Tape};
-use crate::value::{JsonValue, take_value_borrowed, take_value_owned, take_value_skip};
+use crate::value::{JsonValue, JsonValueFloatMode, take_value_borrowed, take_value_owned, take_value_skip};
 use crate::{JsonError, JsonErrorType, PartialMode};
 
 pub type JiterResult<T> = Result<T, JiterError>;
@@ -244,6 +244,7 @@ impl<'j> Jiter<'j> {
             DEFAULT_RECURSION_LIMIT,
             self.allow_inf_nan,
             PartialMode::Off,
+            JsonValueFloatMode::Float,
         )
         .map_err(Into::into)
     }
@@ -291,6 +292,7 @@ impl<'j> Jiter<'j> {
             DEFAULT_RECURSION_LIMIT,
             self.allow_inf_nan,
             PartialMode::Off,
+            JsonValueFloatMode::Float,
         )
         .map_err(Into::into)
     }

--- a/crates/jiter/src/lib.rs
+++ b/crates/jiter/src/lib.rs
@@ -167,7 +167,7 @@ pub use errors::{JiterError, JiterErrorType, JsonError, JsonErrorType, JsonResul
 pub use jiter::{Jiter, JiterResult};
 pub use number_decoder::{NumberAny, NumberFloat, NumberInt};
 pub use parse::Peek;
-pub use value::{JsonArray, JsonObject, JsonValue};
+pub use value::{JsonArray, JsonObject, JsonValue, JsonValueFloatMode};
 
 #[cfg(feature = "python")]
 pub use py_lossless_float::{FloatMode, LosslessFloat};

--- a/crates/jiter/src/parse.rs
+++ b/crates/jiter/src/parse.rs
@@ -70,7 +70,7 @@ impl<'j> Parser<'j> {
     }
 
     #[allow(dead_code)]
-    pub fn slice(&self, range: Range<usize>) -> Option<&[u8]> {
+    pub fn slice(&self, range: Range<usize>) -> Option<&'j [u8]> {
         self.data.get(range)
     }
 

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -20,9 +20,21 @@ pub enum JsonValue<'s> {
     #[cfg(feature = "num-bigint")]
     BigInt(BigInt),
     Float(f64),
+    /// A non-integer JSON number preserved as its original token.
+    LosslessFloat(Cow<'s, str>),
     Str(Cow<'s, str>),
     Array(JsonArray<'s>),
     Object(JsonObject<'s>),
+}
+
+/// Controls how non-integer JSON numbers are represented in [`JsonValue`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum JsonValueFloatMode {
+    /// Parse non-integer numbers as [`JsonValue::Float`].
+    #[default]
+    Float,
+    /// Preserve non-integer numbers as [`JsonValue::LosslessFloat`].
+    LosslessFloat,
 }
 
 /// Parsed JSON array.
@@ -48,6 +60,9 @@ impl<'py> pyo3::IntoPyObject<'py> for JsonValue<'_> {
             #[cfg(feature = "num-bigint")]
             Self::BigInt(b) => Ok(b.into_pyobject(py)?.into_any()),
             Self::Float(f) => Ok(f.into_pyobject(py)?.into_any()),
+            Self::LosslessFloat(f) => crate::LosslessFloat::new_unchecked(f.as_bytes().to_vec())
+                .into_pyobject(py)
+                .map(pyo3::Bound::into_any),
             Self::Str(s) => Ok(s.into_pyobject(py)?.into_any()),
             Self::Array(v) => Ok(pyo3::types::PyList::new(py, v.iter())?.into_any()),
             Self::Object(o) => {
@@ -76,6 +91,9 @@ impl<'py> pyo3::IntoPyObject<'py> for &'_ JsonValue<'_> {
             #[cfg(feature = "num-bigint")]
             JsonValue::BigInt(b) => Ok(b.into_pyobject(py)?.into_any()),
             JsonValue::Float(f) => Ok(f.into_pyobject(py)?.into_any()),
+            JsonValue::LosslessFloat(f) => crate::LosslessFloat::new_unchecked(f.as_bytes().to_vec())
+                .into_pyobject(py)
+                .map(pyo3::Bound::into_any),
             JsonValue::Str(s) => Ok(s.into_pyobject(py)?.into_any()),
             JsonValue::Array(v) => Ok(pyo3::types::PyList::new(py, v.iter())?.into_any()),
             JsonValue::Object(o) => {
@@ -101,6 +119,16 @@ impl<'j> JsonValue<'j> {
         allow_inf_nan: bool,
         allow_partial: PartialMode,
     ) -> Result<Self, JsonError> {
+        Self::parse_with_float_mode(data, allow_inf_nan, allow_partial, JsonValueFloatMode::Float)
+    }
+
+    /// Parse a JSON enum from a byte slice with control over how non-integer numbers are represented.
+    pub fn parse_with_float_mode(
+        data: &'j [u8],
+        allow_inf_nan: bool,
+        allow_partial: PartialMode,
+        float_mode: JsonValueFloatMode,
+    ) -> Result<Self, JsonError> {
         let mut parser = Parser::new(data);
 
         let mut tape = Tape::default();
@@ -112,6 +140,7 @@ impl<'j> JsonValue<'j> {
             DEFAULT_RECURSION_LIMIT,
             allow_inf_nan,
             allow_partial,
+            float_mode,
         )?;
         if !allow_partial.is_active() {
             parser.finish()?;
@@ -148,6 +177,7 @@ fn value_static(v: JsonValue<'_>) -> JsonValue<'static> {
         #[cfg(feature = "num-bigint")]
         JsonValue::BigInt(b) => JsonValue::BigInt(b),
         JsonValue::Float(f) => JsonValue::Float(f),
+        JsonValue::LosslessFloat(f) => JsonValue::LosslessFloat(f.into_owned().into()),
         JsonValue::Str(s) => JsonValue::Str(s.into_owned().into()),
         JsonValue::Array(v) => JsonValue::Array(Arc::new(v.iter().map(JsonValue::to_static).collect())),
         JsonValue::Object(o) => JsonValue::Object(Arc::new(
@@ -161,6 +191,16 @@ fn value_static(v: JsonValue<'_>) -> JsonValue<'static> {
 impl JsonValue<'static> {
     /// Parse a JSON enum from a byte slice, returning an owned version of the enum.
     pub fn parse_owned(data: &[u8], allow_inf_nan: bool, allow_partial: PartialMode) -> Result<Self, JsonError> {
+        Self::parse_owned_with_float_mode(data, allow_inf_nan, allow_partial, JsonValueFloatMode::Float)
+    }
+
+    /// Parse a JSON enum from a byte slice into an owned value with control over non-integer numbers.
+    pub fn parse_owned_with_float_mode(
+        data: &[u8],
+        allow_inf_nan: bool,
+        allow_partial: PartialMode,
+        float_mode: JsonValueFloatMode,
+    ) -> Result<Self, JsonError> {
         let mut parser = Parser::new(data);
 
         let mut tape = Tape::default();
@@ -172,6 +212,7 @@ impl JsonValue<'static> {
             DEFAULT_RECURSION_LIMIT,
             allow_inf_nan,
             allow_partial,
+            float_mode,
         )?;
         parser.finish()?;
         Ok(v)
@@ -185,6 +226,7 @@ pub(crate) fn take_value_borrowed<'j>(
     recursion_limit: u8,
     allow_inf_nan: bool,
     allow_partial: PartialMode,
+    float_mode: JsonValueFloatMode,
 ) -> JsonResult<JsonValue<'j>> {
     take_value(
         peek,
@@ -193,6 +235,7 @@ pub(crate) fn take_value_borrowed<'j>(
         recursion_limit,
         allow_inf_nan,
         allow_partial,
+        float_mode,
         &|s: StringOutput<'_, 'j>| s.into(),
     )
 }
@@ -204,6 +247,7 @@ pub(crate) fn take_value_owned<'j>(
     recursion_limit: u8,
     allow_inf_nan: bool,
     allow_partial: PartialMode,
+    float_mode: JsonValueFloatMode,
 ) -> JsonResult<JsonValue<'static>> {
     take_value(
         peek,
@@ -212,10 +256,12 @@ pub(crate) fn take_value_owned<'j>(
         recursion_limit,
         allow_inf_nan,
         allow_partial,
+        float_mode,
         &|s: StringOutput<'_, 'j>| Into::<String>::into(s).into(),
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn take_value<'j, 's>(
     peek: Peek,
     parser: &mut Parser<'j>,
@@ -223,6 +269,7 @@ fn take_value<'j, 's>(
     recursion_limit: u8,
     allow_inf_nan: bool,
     allow_partial: PartialMode,
+    float_mode: JsonValueFloatMode,
     create_cow: &impl Fn(StringOutput<'_, 'j>) -> Cow<'s, str>,
 ) -> JsonResult<JsonValue<'s>> {
     let partial_active = allow_partial.is_active();
@@ -258,6 +305,7 @@ fn take_value<'j, 's>(
                 recursion_limit,
                 allow_inf_nan,
                 allow_partial,
+                float_mode,
                 create_cow,
             )
         }
@@ -278,28 +326,66 @@ fn take_value<'j, 's>(
                     recursion_limit,
                     allow_inf_nan,
                     allow_partial,
+                    float_mode,
                     create_cow,
                 ),
                 Err(e) if !(partial_active && e.allowed_if_partial()) => Err(e),
                 _ => Ok(JsonValue::empty_object()),
             }
         }
-        _ => {
-            let n = parser.consume_number::<NumberAny>(peek.into_inner(), allow_inf_nan);
-            match n {
-                Ok(NumberAny::Int(NumberInt::Int(int))) => Ok(JsonValue::Int(int)),
-                #[cfg(feature = "num-bigint")]
-                Ok(NumberAny::Int(NumberInt::BigInt(big_int))) => Ok(JsonValue::BigInt(big_int)),
-                Ok(NumberAny::Float(float)) => Ok(JsonValue::Float(float)),
-                Err(e) => {
-                    if !peek.is_num() {
-                        Err(json_error!(ExpectedSomeValue, parser.index))
-                    } else {
-                        Err(e)
-                    }
-                }
+        _ => take_number(peek, parser, allow_inf_nan, float_mode, create_cow),
+    }
+}
+
+fn take_number<'j, 's>(
+    peek: Peek,
+    parser: &mut Parser<'j>,
+    allow_inf_nan: bool,
+    float_mode: JsonValueFloatMode,
+    create_cow: &impl Fn(StringOutput<'_, 'j>) -> Cow<'s, str>,
+) -> JsonResult<JsonValue<'s>> {
+    match float_mode {
+        JsonValueFloatMode::Float => {
+            let number = parser
+                .consume_number::<NumberAny>(peek.into_inner(), allow_inf_nan)
+                .map_err(|e| number_error(peek, parser, e))?;
+            Ok(json_value_from_number_any(number))
+        }
+        JsonValueFloatMode::LosslessFloat => {
+            let number_range = parser
+                .consume_number::<NumberRange>(peek.into_inner(), allow_inf_nan)
+                .map_err(|e| number_error(peek, parser, e))?;
+            let NumberRange { range, is_int } = number_range;
+            let number_bytes = parser.slice(range).unwrap();
+            if is_int {
+                let number = NumberAny::from_bytes(number_bytes, allow_inf_nan).unwrap();
+                Ok(json_value_from_number_any(number))
+            } else {
+                // SAFETY: NumberRange only accepts ASCII JSON number tokens.
+                let number_str = unsafe { std::str::from_utf8_unchecked(number_bytes) };
+                // SAFETY: number_str is an ASCII slice from the original JSON data.
+                Ok(JsonValue::LosslessFloat(create_cow(unsafe {
+                    StringOutput::data(number_str, true)
+                })))
             }
         }
+    }
+}
+
+fn json_value_from_number_any<'s>(number: NumberAny) -> JsonValue<'s> {
+    match number {
+        NumberAny::Int(NumberInt::Int(int)) => JsonValue::Int(int),
+        #[cfg(feature = "num-bigint")]
+        NumberAny::Int(NumberInt::BigInt(big_int)) => JsonValue::BigInt(big_int),
+        NumberAny::Float(float) => JsonValue::Float(float),
+    }
+}
+
+fn number_error(peek: Peek, parser: &Parser, error: JsonError) -> JsonError {
+    if peek.is_num() {
+        error
+    } else {
+        json_error!(ExpectedSomeValue, parser.index)
     }
 }
 
@@ -335,6 +421,7 @@ fn take_value_recursive<'j, 's>(
     recursion_limit: u8,
     allow_inf_nan: bool,
     allow_partial: PartialMode,
+    float_mode: JsonValueFloatMode,
     create_cow: &impl Fn(StringOutput<'_, 'j>) -> Cow<'s, str>,
 ) -> JsonResult<JsonValue<'s>> {
     let recursion_limit: usize = recursion_limit.into();
@@ -390,21 +477,7 @@ fn take_value_recursive<'j, 's>(
                             }
                             Ok(JsonValue::empty_object())
                         }
-                        _ => parser
-                            .consume_number::<NumberAny>(peek.into_inner(), allow_inf_nan)
-                            .map_err(|e| {
-                                if !peek.is_num() {
-                                    json_error!(ExpectedSomeValue, parser.index)
-                                } else {
-                                    e
-                                }
-                            })
-                            .map(|n| match n {
-                                NumberAny::Int(NumberInt::Int(int)) => JsonValue::Int(int),
-                                #[cfg(feature = "num-bigint")]
-                                NumberAny::Int(NumberInt::BigInt(big_int)) => JsonValue::BigInt(big_int),
-                                NumberAny::Float(float) => JsonValue::Float(float),
-                            }),
+                        _ => take_number(peek, parser, allow_inf_nan, float_mode, create_cow),
                     };
 
                     let array = match result {
@@ -475,21 +548,7 @@ fn take_value_recursive<'j, 's>(
                             }
                             Ok(JsonValue::empty_object())
                         }
-                        _ => parser
-                            .consume_number::<NumberAny>(peek.into_inner(), allow_inf_nan)
-                            .map_err(|e| {
-                                if !peek.is_num() {
-                                    json_error!(ExpectedSomeValue, parser.index)
-                                } else {
-                                    e
-                                }
-                            })
-                            .map(|n| match n {
-                                NumberAny::Int(NumberInt::Int(int)) => JsonValue::Int(int),
-                                #[cfg(feature = "num-bigint")]
-                                NumberAny::Int(NumberInt::BigInt(big_int)) => JsonValue::BigInt(big_int),
-                                NumberAny::Float(float) => JsonValue::Float(float),
-                            }),
+                        _ => take_number(peek, parser, allow_inf_nan, float_mode, create_cow),
                     };
 
                     let object = match result {

--- a/crates/jiter/tests/main.rs
+++ b/crates/jiter/tests/main.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use num_bigint::BigInt;
 
 use jiter::{
-    Jiter, JiterErrorType, JiterResult, JsonErrorType, JsonObject, JsonType, JsonValue, LinePosition, NumberAny,
-    NumberFloat, NumberInt, PartialMode, Peek,
+    Jiter, JiterErrorType, JiterResult, JsonErrorType, JsonObject, JsonType, JsonValue, JsonValueFloatMode,
+    LinePosition, NumberAny, NumberFloat, NumberInt, PartialMode, Peek,
 };
 
 fn json_vec(jiter: &mut Jiter, peek: Option<Peek>) -> JiterResult<Vec<String>> {
@@ -1223,6 +1223,76 @@ fn test_owned_value() {
         array,
         &Arc::new(vec![JsonValue::Int(1), JsonValue::Bool(false), JsonValue::Null])
     );
+}
+
+#[test]
+fn test_value_lossless_float_default_is_off() {
+    let value = JsonValue::parse(b"1.234567890123456789012345678901234567890", false).unwrap();
+    assert!(matches!(value, JsonValue::Float(_)));
+}
+
+#[test]
+fn test_value_lossless_float_borrowed() {
+    let json = br#"{"small": 1.2, "big": 12345678901234567890123456789012345678.9, "exp": -4.5e+67, "int": 1}"#;
+    let value =
+        JsonValue::parse_with_float_mode(json, false, PartialMode::Off, JsonValueFloatMode::LosslessFloat).unwrap();
+    let JsonValue::Object(obj) = value else {
+        panic!("expected object")
+    };
+
+    assert_eq!(
+        get_key(&obj, "small").unwrap(),
+        &JsonValue::LosslessFloat(Cow::Borrowed("1.2"))
+    );
+    assert_eq!(
+        get_key(&obj, "big").unwrap(),
+        &JsonValue::LosslessFloat(Cow::Borrowed("12345678901234567890123456789012345678.9"))
+    );
+    assert_eq!(
+        get_key(&obj, "exp").unwrap(),
+        &JsonValue::LosslessFloat(Cow::Borrowed("-4.5e+67"))
+    );
+    assert_eq!(get_key(&obj, "int").unwrap(), &JsonValue::Int(1));
+}
+
+#[test]
+fn test_value_lossless_float_into_static() {
+    let value =
+        JsonValue::parse_with_float_mode(b"1.200", false, PartialMode::Off, JsonValueFloatMode::LosslessFloat).unwrap();
+    assert_eq!(
+        value.into_static(),
+        JsonValue::LosslessFloat(Cow::Owned("1.200".to_string()))
+    );
+}
+
+#[test]
+fn test_value_lossless_float_owned() {
+    let value = JsonValue::parse_owned_with_float_mode(
+        b"[0.1234, 1e3, -0.0]",
+        false,
+        PartialMode::Off,
+        JsonValueFloatMode::LosslessFloat,
+    )
+    .unwrap();
+    assert_eq!(
+        value,
+        JsonValue::Array(Arc::new(vec![
+            JsonValue::LosslessFloat(Cow::Owned("0.1234".to_string())),
+            JsonValue::LosslessFloat(Cow::Owned("1e3".to_string())),
+            JsonValue::LosslessFloat(Cow::Owned("-0.0".to_string())),
+        ]))
+    );
+}
+
+#[test]
+fn test_value_lossless_float_invalid_numbers() {
+    let err = JsonValue::parse_with_float_mode(b"1.", false, PartialMode::Off, JsonValueFloatMode::LosslessFloat)
+        .unwrap_err();
+    assert_eq!(err.error_type, JsonErrorType::EofWhileParsingValue);
+
+    let err =
+        JsonValue::parse_with_float_mode(b"x", false, PartialMode::Off, JsonValueFloatMode::LosslessFloat).unwrap_err();
+    assert_eq!(err.error_type, JsonErrorType::ExpectedSomeValue);
 }
 
 fn value_into_static() -> JsonValue<'static> {

--- a/crates/jiter/tests/python.rs
+++ b/crates/jiter/tests/python.rs
@@ -1,7 +1,9 @@
+use std::borrow::Cow;
+
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 
-use jiter::{JsonValue, PythonParse, StringCacheMode, pystring_ascii_new};
+use jiter::{JsonValue, JsonValueFloatMode, PartialMode, PythonParse, StringCacheMode, pystring_ascii_new};
 
 #[cfg(feature = "num-bigint")]
 #[test]
@@ -32,6 +34,34 @@ fn test_to_py_object_other() {
         let python_value = value.into_pyobject(py).unwrap();
         let string = python_value.to_string();
         assert_eq!(string, "['string', '£', True, False, None, nan, inf, -inf]");
+    });
+}
+
+#[test]
+fn test_to_py_object_lossless_float() {
+    let value = JsonValue::parse_with_float_mode(
+        br#"{"float": 1.234567890123456789}"#,
+        false,
+        PartialMode::Off,
+        JsonValueFloatMode::LosslessFloat,
+    )
+    .unwrap();
+    Python::attach(|py| {
+        let python_value = value.into_pyobject(py).unwrap();
+        let string = python_value.to_string();
+        assert_eq!(string, "{'float': LosslessFloat(1.234567890123456789)}");
+    });
+}
+
+#[test]
+fn test_to_py_object_lossless_float_owned() {
+    Python::attach(|py| {
+        let value = JsonValue::LosslessFloat(Cow::Borrowed("1.234567890123456789"));
+        let python_value = pyo3::IntoPyObject::into_pyobject(value, py).unwrap();
+        assert_eq!(
+            python_value.repr().unwrap().to_string(),
+            "LosslessFloat(1.234567890123456789)"
+        );
     });
 }
 


### PR DESCRIPTION
Adds an opt-in `JsonValueFloatMode::LosslessFloat` mode that preserves non-integer JSON numbers as `JsonValue::LosslessFloat(Cow<str>)` instead of forcing them through `f64`.

Default parsing stays unchanged.

Intended to allow deserialization of numbers of arbitrary precision.

Addresses https://github.com/pydantic/jiter/issues/230

After merging I'll open an integration pull request into pydantic.