### PR TITLE
Add `serde` Deserializer implementation

### DIFF
--- a/crates/jiter/Cargo.toml
+++ b/crates/jiter/Cargo.toml
@@ -20,11 +20,13 @@ smallvec = "1.11.0"
 pyo3 = { workspace = true, optional = true }
 lexical-parse-float = { version = "1.0.5", features = ["format"] }
 bitvec = "1.0.1"
+serde = { version = "1.0.147", optional = true }
 
 [features]
 default = ["num-bigint"]
 python = ["dep:pyo3", "dep:pyo3-build-config"]
 num-bigint = ["dep:num-bigint", "pyo3?/num-bigint"]
+serde = ["dep:serde"]
 
 [dev-dependencies]
 paste = "1.0.7"
@@ -33,7 +35,7 @@ serde_json = { version = "1.0.87", features = [
     "arbitrary_precision",
     "float_roundtrip",
 ] }
-serde = "1.0.147"
+serde = { version = "1.0.147", features = ["derive"] }
 pyo3 = { workspace = true, features = ["auto-initialize"] }
 codspeed-criterion-compat = "2.7.2"
 
@@ -43,6 +45,10 @@ pyo3-build-config = { workspace = true, optional = true }
 [[test]]
 name = "python"
 required-features = ["python"]
+
+[[test]]
+name = "serde"
+required-features = ["serde"]
 
 [[bench]]
 name = "main"

--- a/crates/jiter/Cargo.toml
+++ b/crates/jiter/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = { version = "1.0.87", features = [
 serde = { version = "1.0.147", features = ["derive"] }
 pyo3 = { workspace = true, features = ["auto-initialize"] }
 codspeed-criterion-compat = "2.7.2"
+proptest = "1.4.0"
 
 [build-dependencies]
 pyo3-build-config = { workspace = true, optional = true }

--- a/crates/jiter/src/lib.rs
+++ b/crates/jiter/src/lib.rs
@@ -158,6 +158,8 @@ mod py_lossless_float;
 mod py_string_cache;
 #[cfg(feature = "python")]
 mod python;
+#[cfg(feature = "serde")]
+pub mod serde;
 #[cfg(target_arch = "aarch64")]
 mod simd_aarch64;
 mod string_decoder;

--- a/crates/jiter/src/serde.rs
+++ b/crates/jiter/src/serde.rs
@@ -1,0 +1,673 @@
+//! A [`serde`] [`Deserializer`](::serde::Deserializer) backed by jiter's parser.
+//!
+//! Unescaped strings are deserialized zero-copy: the parser leaves them in the input, so a borrowed
+//! `&'de str` is handed to [`visit_borrowed_str`]. Escaped strings are decoded onto a scratch tape
+//! and passed transiently to [`visit_str`]. Borrowing a string into the target therefore requires
+//! the input to outlive the deserialized value.
+//!
+//! [`visit_borrowed_str`]: ::serde::de::Visitor::visit_borrowed_str
+//! [`visit_str`]: ::serde::de::Visitor::visit_str
+//!
+//! ## Numbers
+//!
+//! Integers up to `i64`/`u64` deserialize losslessly. Larger integers need the `num-bigint` feature
+//! (on by default): values widen to `i128`/`u128`, falling back to `f64` past `u128`. Without it,
+//! integers outside the `i64` range error with [`JsonErrorType::NumberOutOfRange`].
+//!
+//! Non-finite floats (`NaN`/`Infinity`, enabled via [`JiterDeserializer::with_allow_inf_nan`], or
+//! produced by overflow) reach a typed `f64`/`f32` target as the real value, but a
+//! `deserialize_any` target (which can't hold them) receives the canonical string
+//! `"NaN"`/`"Infinity"`/`"-Infinity"`.
+//!
+//! ```rust
+//! use serde::Deserialize;
+//!
+//! #[derive(Deserialize, PartialEq, Debug)]
+//! struct Person<'a> {
+//!     name: &'a str,
+//!     age: u8,
+//! }
+//!
+//! let person: Person = jiter::serde::from_str(r#"{"name": "John", "age": 43}"#).unwrap();
+//! assert_eq!(person, Person { name: "John", age: 43 });
+//! ```
+
+use std::fmt::{self, Display};
+
+use serde::de::{self, Deserializer as _, EnumAccess, IntoDeserializer, MapAccess, SeqAccess, VariantAccess, Visitor};
+use serde::forward_to_deserialize_any;
+
+use crate::errors::{DEFAULT_RECURSION_LIMIT, JsonError, JsonErrorType, LinePosition};
+use crate::number_decoder::{NumberAny, NumberInt};
+use crate::parse::{Parser, Peek};
+use crate::string_decoder::{StringDecoder, StringOutput, StringOutputType, Tape};
+use crate::value::take_value_skip;
+
+/// Ways a JSON value can fail to match an enum's expected shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnumError {
+    /// neither a string (unit variant) nor a single-key object
+    NotStringOrSingleKeyObject,
+    /// the object did not contain exactly one key
+    NotSingleKey,
+}
+
+impl Display for EnumError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::NotStringOrSingleKeyObject => "expected a string or single-key object for an enum",
+            Self::NotSingleKey => "expected a single-key object for an enum",
+        })
+    }
+}
+
+/// An error from deserializing JSON with [`JiterDeserializer`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    /// A JSON syntax error from the parser.
+    Syntax(JsonError),
+    /// A `serde` error (type mismatch, missing field, …); `index` is set when the position is known.
+    Data { message: String, index: Option<usize> },
+    /// A malformed enum encoding.
+    Enum { kind: EnumError, index: usize },
+}
+
+impl Error {
+    /// The byte index where the error occurred, if known.
+    pub fn index(&self) -> Option<usize> {
+        match self {
+            Self::Syntax(err) => Some(err.index),
+            Self::Data { index, .. } => *index,
+            Self::Enum { index, .. } => Some(*index),
+        }
+    }
+
+    /// Line/column of the error within `data`, if the position is known.
+    pub fn get_position(&self, data: &[u8]) -> Option<LinePosition> {
+        self.index().map(|index| LinePosition::find(data, index))
+    }
+
+    /// The error with its line/column resolved against `data` (when known).
+    pub fn description(&self, data: &[u8]) -> String {
+        match self {
+            Self::Syntax(err) => err.description(data),
+            Self::Data {
+                message,
+                index: Some(index),
+            } => format!("{message} at {}", LinePosition::find(data, *index)),
+            Self::Data { message, index: None } => message.to_string(),
+            Self::Enum { kind, index } => format!("{kind} at {}", LinePosition::find(data, *index)),
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Syntax(err) => write!(f, "{err}"),
+            Self::Data {
+                message,
+                index: Some(index),
+            } => write!(f, "{message} at index {index}"),
+            Self::Data { message, index: None } => f.write_str(message),
+            Self::Enum { kind, index } => write!(f, "{kind} at index {index}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Syntax(err) => Some(err),
+            Self::Data { .. } | Self::Enum { .. } => None,
+        }
+    }
+}
+
+impl From<JsonError> for Error {
+    fn from(err: JsonError) -> Self {
+        Self::Syntax(err)
+    }
+}
+
+impl de::Error for Error {
+    fn custom<T: Display>(msg: T) -> Self {
+        // no position available here; `stamp_index` fills it in as the error unwinds
+        Self::Data {
+            message: msg.to_string(),
+            index: None,
+        }
+    }
+}
+
+/// Fill in the position of an as-yet-unpositioned [`Error::Data`] as it unwinds through
+/// `deserialize_any`, where the parser is frozen at the failing value.
+fn stamp_index(mut err: Error, index: usize) -> Error {
+    if let Error::Data { index: slot @ None, .. } = &mut err {
+        *slot = Some(index);
+    }
+    err
+}
+
+/// Deserialize an instance of `T` from a slice of JSON bytes.
+pub fn from_slice<'a, T>(data: &'a [u8]) -> Result<T, Error>
+where
+    T: serde::Deserialize<'a>,
+{
+    let mut de = JiterDeserializer::new(data);
+    let value = T::deserialize(&mut de)?;
+    de.finish()?;
+    Ok(value)
+}
+
+/// Deserialize an instance of `T` from a string of JSON.
+pub fn from_str<'a, T>(data: &'a str) -> Result<T, Error>
+where
+    T: serde::Deserialize<'a>,
+{
+    from_slice(data.as_bytes())
+}
+
+/// A [`serde::Deserializer`] backed by jiter's parser.
+#[derive(Debug)]
+pub struct JiterDeserializer<'j> {
+    parser: Parser<'j>,
+    tape: Tape,
+    allow_inf_nan: bool,
+    /// Max nesting depth; `None` disables the check.
+    recursion_limit: Option<usize>,
+    /// Current nesting depth.
+    depth: usize,
+}
+
+impl<'j> JiterDeserializer<'j> {
+    /// Construct a new `JiterDeserializer` from a slice of JSON bytes.
+    pub fn new(data: &'j [u8]) -> Self {
+        Self {
+            parser: Parser::new(data),
+            tape: Tape::new(),
+            allow_inf_nan: false,
+            recursion_limit: Some(usize::from(DEFAULT_RECURSION_LIMIT)),
+            depth: 0,
+        }
+    }
+
+    /// Allow `NaN`, `Infinity` and `-Infinity` in numbers (off by default).
+    pub fn with_allow_inf_nan(mut self) -> Self {
+        self.allow_inf_nan = true;
+        self
+    }
+
+    /// Set the max nesting depth (default [`DEFAULT_RECURSION_LIMIT`]); deeper input errors with
+    /// [`JsonErrorType::RecursionLimitExceeded`].
+    pub fn with_recursion_limit(mut self, limit: usize) -> Self {
+        self.recursion_limit = Some(limit);
+        self
+    }
+
+    /// Disable the recursion limit; deeply nested input may then overflow the stack.
+    pub fn disable_recursion_limit(mut self) -> Self {
+        self.recursion_limit = None;
+        self
+    }
+
+    /// Error unless all input has been consumed.
+    pub fn finish(&mut self) -> Result<(), Error> {
+        self.parser.finish().map_err(Error::from)
+    }
+
+    /// Enter a nested array/object, enforcing the recursion limit.
+    fn enter(&mut self) -> Result<(), Error> {
+        self.depth += 1;
+        match self.recursion_limit {
+            Some(limit) if self.depth > limit => Err(Error::Syntax(JsonError::new(
+                JsonErrorType::RecursionLimitExceeded,
+                self.parser.index,
+            ))),
+            _ => Ok(()),
+        }
+    }
+
+    /// Leave a nested array/object.
+    fn leave(&mut self) {
+        self.depth -= 1;
+    }
+
+    /// Remaining depth budget for [`take_value_skip`] (`u8`-limited); `u8::MAX` when disabled.
+    fn skip_recursion_budget(&self) -> u8 {
+        match self.recursion_limit {
+            None => u8::MAX,
+            Some(limit) => limit.saturating_sub(self.depth).try_into().unwrap_or(u8::MAX),
+        }
+    }
+}
+
+impl<'de> de::Deserializer<'de> for &mut JiterDeserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let peek = self.parser.peek()?;
+        // value start, used to position a serde error raised by the visitor
+        let start = self.parser.index;
+        match peek {
+            Peek::Null => {
+                self.parser.consume_null()?;
+                visitor.visit_unit()
+            }
+            Peek::True => {
+                self.parser.consume_true()?;
+                visitor.visit_bool(true)
+            }
+            Peek::False => {
+                self.parser.consume_false()?;
+                visitor.visit_bool(false)
+            }
+            Peek::String => {
+                let output = self.parser.consume_string::<StringDecoder>(&mut self.tape, false)?;
+                visit_str_output(&output, visitor)
+            }
+            Peek::Array => {
+                self.enter()?;
+                let mut seq = JiterSeqAccess {
+                    de: &mut *self,
+                    first: true,
+                    ended: false,
+                };
+                let value = visitor.visit_seq(&mut seq)?;
+                // consume `]`, rejecting any elements a fixed-size consumer left behind
+                seq.finish()?;
+                self.leave();
+                Ok(value)
+            }
+            Peek::Object => {
+                self.enter()?;
+                let value = visitor.visit_map(JiterMapAccess {
+                    de: &mut *self,
+                    first: true,
+                })?;
+                self.leave();
+                Ok(value)
+            }
+            // otherwise a number (or an invalid token, which `consume_number` reports)
+            _ => match self
+                .parser
+                .consume_number::<NumberAny>(peek.into_inner(), self.allow_inf_nan)?
+            {
+                NumberAny::Int(int) => visit_int(int, visitor),
+                NumberAny::Float(f) if f.is_finite() => visitor.visit_f64(f),
+                // this target can't hold a non-finite float; emit the canonical string instead.
+                // typed `f64`/`f32` bypass this via `deserialize_number` and get the real value.
+                NumberAny::Float(f) => visitor.visit_borrowed_str(non_finite_str(f)),
+            },
+        }
+        .map_err(|e| stamp_index(e, start))
+    }
+
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        if self.parser.peek()? == Peek::Null {
+            self.parser.consume_null()?;
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self.parser.peek()? {
+            // bare string: unit variant
+            Peek::String => visitor.visit_enum(JiterEnumAccess { de: self, unit: true }),
+            // single-key object: the wrapper counts toward the recursion limit like any nesting,
+            // otherwise a recursive enum could bypass the limit and overflow the stack
+            Peek::Object => {
+                self.enter()?;
+                let value = visitor.visit_enum(JiterEnumAccess {
+                    de: &mut *self,
+                    unit: false,
+                })?;
+                self.leave();
+                Ok(value)
+            }
+            _ => Err(Error::Enum {
+                kind: EnumError::NotStringOrSingleKeyObject,
+                index: self.parser.index,
+            }),
+        }
+    }
+
+    /// Typed float target: receives the real value, including non-finite (unlike `deserialize_any`).
+    fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        deserialize_number(self, visitor)
+    }
+
+    fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        deserialize_number(self, visitor)
+    }
+
+    /// Skip the next value without decoding it.
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let peek = self.parser.peek()?;
+        let recursion_limit = self.skip_recursion_budget();
+        take_value_skip(
+            peek,
+            &mut self.parser,
+            &mut self.tape,
+            recursion_limit,
+            self.allow_inf_nan,
+        )?;
+        visitor.visit_unit()
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
+        bytes byte_buf unit unit_struct seq tuple tuple_struct map struct identifier
+    }
+}
+
+/// Deserialize a number for a typed float target, keeping non-finite values as real `f64`s.
+fn deserialize_number<'de, V: Visitor<'de>>(de: &mut JiterDeserializer<'de>, visitor: V) -> Result<V::Value, Error> {
+    let peek = de.parser.peek()?;
+    if peek.is_num() {
+        match de
+            .parser
+            .consume_number::<NumberAny>(peek.into_inner(), de.allow_inf_nan)?
+        {
+            NumberAny::Int(int) => visit_int(int, visitor),
+            NumberAny::Float(f) => visitor.visit_f64(f),
+        }
+    } else {
+        // not a number: let `deserialize_any` produce the type error
+        (&mut *de).deserialize_any(visitor)
+    }
+}
+
+/// Canonical text for a non-finite float.
+fn non_finite_str(f: f64) -> &'static str {
+    if f.is_nan() {
+        "NaN"
+    } else if f < 0.0 {
+        "-Infinity"
+    } else {
+        "Infinity"
+    }
+}
+
+/// Visit a decoded string, borrowing from the input when it wasn't escaped.
+fn visit_str_output<'de, V: Visitor<'de>>(output: &StringOutput<'_, 'de>, visitor: V) -> Result<V::Value, Error> {
+    match &output.data {
+        // unescaped: borrow `&'de str`
+        StringOutputType::Data(s) => visitor.visit_borrowed_str(s),
+        // escaped: transient tape borrow
+        StringOutputType::Tape(s) => visitor.visit_str(s),
+    }
+}
+
+/// Visit an integer, narrowing big ints to the smallest primitive that fits.
+fn visit_int<'de, V: Visitor<'de>>(int: NumberInt, visitor: V) -> Result<V::Value, Error> {
+    match int {
+        NumberInt::Int(i) => visitor.visit_i64(i),
+        #[cfg(feature = "num-bigint")]
+        NumberInt::BigInt(big) => {
+            use num_traits::ToPrimitive;
+            if let Some(i) = big.to_i128() {
+                visitor.visit_i128(i)
+            } else if let Some(u) = big.to_u128() {
+                visitor.visit_u128(u)
+            } else {
+                visitor.visit_f64(big.to_f64().unwrap_or(f64::NAN))
+            }
+        }
+    }
+}
+
+struct JiterSeqAccess<'a, 'de> {
+    de: &'a mut JiterDeserializer<'de>,
+    first: bool,
+    /// `true` once the closing `]` has been consumed.
+    ended: bool,
+}
+
+impl JiterSeqAccess<'_, '_> {
+    /// The next element's [`Peek`], or `None` (consuming `]`) at the end.
+    fn step(&mut self) -> Result<Option<Peek>, Error> {
+        let peek = if std::mem::take(&mut self.first) {
+            self.de.parser.array_first()?
+        } else {
+            self.de.parser.array_step()?
+        };
+        if peek.is_none() {
+            self.ended = true;
+        }
+        Ok(peek)
+    }
+
+    /// Consume `]`; error if elements remain (a fixed-size target took fewer than the array holds).
+    fn finish(&mut self) -> Result<(), Error> {
+        while !self.ended {
+            if self.step()?.is_some() {
+                return Err(Error::Syntax(JsonError::new(
+                    JsonErrorType::TrailingCharacters,
+                    self.de.parser.index,
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'de> SeqAccess<'de> for &mut JiterSeqAccess<'_, 'de> {
+    type Error = Error;
+
+    fn next_element_seed<T: de::DeserializeSeed<'de>>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error> {
+        // the parser is left at the next value, which `deserialize_any`'s `peek` reads idempotently
+        match self.step()? {
+            Some(_) => seed.deserialize(&mut *self.de).map(Some),
+            None => Ok(None),
+        }
+    }
+}
+
+struct JiterMapAccess<'a, 'de> {
+    de: &'a mut JiterDeserializer<'de>,
+    first: bool,
+}
+
+impl<'de> MapAccess<'de> for JiterMapAccess<'_, 'de> {
+    type Error = Error;
+
+    fn next_key_seed<K: de::DeserializeSeed<'de>>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error> {
+        let output = if std::mem::take(&mut self.first) {
+            self.de.parser.object_first::<StringDecoder>(&mut self.de.tape)?
+        } else {
+            self.de.parser.object_step::<StringDecoder>(&mut self.de.tape)?
+        };
+        // the key parse also consumes the colon; the key is fully deserialized here, before the
+        // value reuses the tape, so a tape-backed key is safe
+        match output {
+            Some(output) => seed.deserialize(MapKeyDeserializer { key: output.data }).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V: de::DeserializeSeed<'de>>(&mut self, seed: V) -> Result<V::Value, Self::Error> {
+        seed.deserialize(&mut *self.de)
+    }
+}
+
+/// Deserializer for object keys: borrows the key string, or parses it for primitive targets.
+struct MapKeyDeserializer<'t, 'de> {
+    key: StringOutputType<'t, 'de>,
+}
+
+impl MapKeyDeserializer<'_, '_> {
+    fn as_str(&self) -> &str {
+        match self.key {
+            StringOutputType::Tape(s) | StringOutputType::Data(s) => s,
+        }
+    }
+}
+
+macro_rules! deserialize_key_parsed {
+    ($method:ident, $visit:ident, $ty:ty) => {
+        fn $method<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+            match self.as_str().parse::<$ty>() {
+                Ok(value) => visitor.$visit(value),
+                Err(_) => self.deserialize_any(visitor),
+            }
+        }
+    };
+}
+
+impl<'de> de::Deserializer<'de> for MapKeyDeserializer<'_, 'de> {
+    type Error = Error;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.key {
+            StringOutputType::Data(s) => visitor.visit_borrowed_str(s),
+            StringOutputType::Tape(s) => visitor.visit_str(s),
+        }
+    }
+
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        // the key string is the (unit) variant name
+        let de: de::value::StrDeserializer<Error> = self.as_str().into_deserializer();
+        de.deserialize_enum(name, variants, visitor)
+    }
+
+    // parse the key string for primitive targets (e.g. integer keys); fall back to the string on
+    // failure so the visitor reports the type error
+    deserialize_key_parsed!(deserialize_bool, visit_bool, bool);
+    deserialize_key_parsed!(deserialize_i8, visit_i8, i8);
+    deserialize_key_parsed!(deserialize_i16, visit_i16, i16);
+    deserialize_key_parsed!(deserialize_i32, visit_i32, i32);
+    deserialize_key_parsed!(deserialize_i64, visit_i64, i64);
+    deserialize_key_parsed!(deserialize_i128, visit_i128, i128);
+    deserialize_key_parsed!(deserialize_u8, visit_u8, u8);
+    deserialize_key_parsed!(deserialize_u16, visit_u16, u16);
+    deserialize_key_parsed!(deserialize_u32, visit_u32, u32);
+    deserialize_key_parsed!(deserialize_u64, visit_u64, u64);
+    deserialize_key_parsed!(deserialize_u128, visit_u128, u128);
+    deserialize_key_parsed!(deserialize_f32, visit_f32, f32);
+    deserialize_key_parsed!(deserialize_f64, visit_f64, f64);
+
+    forward_to_deserialize_any! {
+        char str string bytes byte_buf option unit unit_struct newtype_struct
+        seq tuple tuple_struct map struct identifier ignored_any
+    }
+}
+
+struct JiterEnumAccess<'a, 'de> {
+    de: &'a mut JiterDeserializer<'de>,
+    /// `true` for the bare-string (unit variant) form.
+    unit: bool,
+}
+
+impl<'a, 'de> EnumAccess<'de> for JiterEnumAccess<'a, 'de> {
+    type Error = Error;
+    type Variant = JiterVariantAccess<'a, 'de>;
+
+    fn variant_seed<V: de::DeserializeSeed<'de>>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error> {
+        let key = if self.unit {
+            self.de
+                .parser
+                .consume_string::<StringDecoder>(&mut self.de.tape, false)?
+                .data
+        } else {
+            let start = self.de.parser.index;
+            // consumes `{` and the variant key, leaving the parser at the variant's value
+            match self.de.parser.object_first::<StringDecoder>(&mut self.de.tape)? {
+                Some(output) => output.data,
+                None => {
+                    return Err(Error::Enum {
+                        kind: EnumError::NotSingleKey,
+                        index: start,
+                    });
+                }
+            }
+        };
+        let value = seed.deserialize(MapKeyDeserializer { key })?;
+        Ok((
+            value,
+            JiterVariantAccess {
+                de: self.de,
+                unit: self.unit,
+            },
+        ))
+    }
+}
+
+struct JiterVariantAccess<'a, 'de> {
+    de: &'a mut JiterDeserializer<'de>,
+    unit: bool,
+}
+
+impl JiterVariantAccess<'_, '_> {
+    /// Consume the closing `}` of an object variant, erroring on extra keys.
+    fn finish(&mut self) -> Result<(), Error> {
+        if self.unit {
+            Ok(())
+        } else {
+            match self.de.parser.object_step::<StringDecoder>(&mut self.de.tape)? {
+                None => Ok(()),
+                Some(_) => Err(Error::Enum {
+                    kind: EnumError::NotSingleKey,
+                    index: self.de.parser.index,
+                }),
+            }
+        }
+    }
+}
+
+impl<'de> VariantAccess<'de> for JiterVariantAccess<'_, 'de> {
+    type Error = Error;
+
+    fn unit_variant(mut self) -> Result<(), Self::Error> {
+        if self.unit {
+            // bare-string form
+            Ok(())
+        } else {
+            // object form: the content must be `()` (i.e. `null`); consume it, then close the object
+            <() as de::Deserialize>::deserialize(&mut *self.de)?;
+            self.finish()
+        }
+    }
+
+    fn newtype_variant_seed<T: de::DeserializeSeed<'de>>(mut self, seed: T) -> Result<T::Value, Self::Error> {
+        let value = seed.deserialize(&mut *self.de)?;
+        self.finish()?;
+        Ok(value)
+    }
+
+    fn tuple_variant<V: Visitor<'de>>(mut self, _len: usize, visitor: V) -> Result<V::Value, Self::Error> {
+        let value = (&mut *self.de).deserialize_seq(visitor)?;
+        self.finish()?;
+        Ok(value)
+    }
+
+    fn struct_variant<V: Visitor<'de>>(
+        mut self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        let value = (&mut *self.de).deserialize_map(visitor)?;
+        self.finish()?;
+        Ok(value)
+    }
+}

--- a/crates/jiter/src/serde.rs
+++ b/crates/jiter/src/serde.rs
@@ -66,8 +66,10 @@ impl Display for EnumError {
 pub enum Error {
     /// A JSON syntax error from the parser.
     Syntax(JsonError),
-    /// A `serde` error (type mismatch, missing field, …); `index` is set when the position is known.
-    Data { message: String, index: Option<usize> },
+    /// A `serde` error (type mismatch, missing field, …) whose byte position isn't yet known.
+    Message(String),
+    /// A `serde` error (type mismatch, missing field, …) at byte `index`.
+    Data { message: String, index: usize },
     /// A malformed enum encoding.
     Enum { kind: EnumError, index: usize },
 }
@@ -77,8 +79,8 @@ impl Error {
     pub fn index(&self) -> Option<usize> {
         match self {
             Self::Syntax(err) => Some(err.index),
-            Self::Data { index, .. } => *index,
-            Self::Enum { index, .. } => Some(*index),
+            Self::Data { index, .. } | Self::Enum { index, .. } => Some(*index),
+            Self::Message(_) => None,
         }
     }
 
@@ -91,12 +93,20 @@ impl Error {
     pub fn description(&self, data: &[u8]) -> String {
         match self {
             Self::Syntax(err) => err.description(data),
-            Self::Data {
-                message,
-                index: Some(index),
-            } => format!("{message} at {}", LinePosition::find(data, *index)),
-            Self::Data { message, index: None } => message.to_string(),
+            Self::Data { message, index } => format!("{message} at {}", LinePosition::find(data, *index)),
             Self::Enum { kind, index } => format!("{kind} at {}", LinePosition::find(data, *index)),
+            Self::Message(message) => message.clone(),
+        }
+    }
+
+    /// Position an as-yet-unpositioned [`Message`](Error::Message) at `index`; a no-op otherwise.
+    ///
+    /// Called as the error unwinds past the failing value (where the parser is frozen), and once
+    /// more at the deserialization boundary to catch any error that bypassed the unwinding path.
+    fn with_index(self, index: usize) -> Self {
+        match self {
+            Self::Message(message) => Self::Data { message, index },
+            positioned => positioned,
         }
     }
 }
@@ -105,12 +115,9 @@ impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Syntax(err) => write!(f, "{err}"),
-            Self::Data {
-                message,
-                index: Some(index),
-            } => write!(f, "{message} at index {index}"),
-            Self::Data { message, index: None } => f.write_str(message),
+            Self::Data { message, index } => write!(f, "{message} at index {index}"),
             Self::Enum { kind, index } => write!(f, "{kind} at index {index}"),
+            Self::Message(message) => f.write_str(message),
         }
     }
 }
@@ -119,7 +126,7 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Syntax(err) => Some(err),
-            Self::Data { .. } | Self::Enum { .. } => None,
+            Self::Data { .. } | Self::Enum { .. } | Self::Message(_) => None,
         }
     }
 }
@@ -132,21 +139,9 @@ impl From<JsonError> for Error {
 
 impl de::Error for Error {
     fn custom<T: Display>(msg: T) -> Self {
-        // no position available here; `stamp_index` fills it in as the error unwinds
-        Self::Data {
-            message: msg.to_string(),
-            index: None,
-        }
+        // a visitor has only a message; `with_index` supplies the position as the error unwinds
+        Self::Message(msg.to_string())
     }
-}
-
-/// Fill in the position of an as-yet-unpositioned [`Error::Data`] as it unwinds through
-/// `deserialize_any`, where the parser is frozen at the failing value.
-fn stamp_index(mut err: Error, index: usize) -> Error {
-    if let Error::Data { index: slot @ None, .. } = &mut err {
-        *slot = Some(index);
-    }
-    err
 }
 
 /// Deserialize an instance of `T` from a slice of JSON bytes.
@@ -155,7 +150,9 @@ where
     T: serde::Deserialize<'a>,
 {
     let mut de = JiterDeserializer::new(data);
-    let value = T::deserialize(&mut de)?;
+    let result = T::deserialize(&mut de);
+    // position any error that reached the boundary unpositioned, at where the parser stopped
+    let value = result.map_err(|e| e.with_index(de.parser.index))?;
     de.finish()?;
     Ok(value)
 }
@@ -300,7 +297,7 @@ impl<'de> de::Deserializer<'de> for &mut JiterDeserializer<'de> {
                 NumberAny::Float(f) => visitor.visit_borrowed_str(non_finite_str(f)),
             },
         }
-        .map_err(|e| stamp_index(e, start))
+        .map_err(|e| e.with_index(start))
     }
 
     fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {

--- a/crates/jiter/src/string_decoder.rs
+++ b/crates/jiter/src/string_decoder.rs
@@ -45,7 +45,7 @@ mod string_output {
     where
         'j: 't,
     {
-        data: StringOutputType<'t, 'j>,
+        pub(crate) data: StringOutputType<'t, 'j>,
         // SAFETY: this is used as an invariant to determine if the string is ascii only
         // so this should not be set except when known
         ascii_only: bool,

--- a/crates/jiter/tests/serde.rs
+++ b/crates/jiter/tests/serde.rs
@@ -212,6 +212,16 @@ fn type_error_carries_real_position() {
 }
 
 #[test]
+fn top_level_unknown_variant_is_positioned() {
+    // an unknown variant on a top-level enum is reported during variant identification and never
+    // unwinds through `deserialize_any`, so the error must be positioned at the boundary rather than
+    // reaching the caller as a bare, unpositioned `Message`
+    let err = from_str::<Shape>(r#"{"Nope": 1}"#).unwrap_err();
+    assert!(matches!(err, Error::Data { .. }), "got {err:?}");
+    assert!(err.index().is_some(), "unknown-variant error should carry a position");
+}
+
+#[test]
 fn error_resolves_to_line_and_column() {
     #[derive(Deserialize, Debug)]
     #[allow(dead_code)]
@@ -420,4 +430,95 @@ fn matches_serde_json() {
     let from_jiter: Doc = from_str(data).unwrap();
     let from_serde: Doc = serde_json::from_str(data).unwrap();
     assert_eq!(from_jiter, from_serde);
+}
+
+// --- differential property tests against serde_json ---------------------------------------------
+//
+// We generate an arbitrary `serde_json::Value`, serialize it, then parse it back with both
+// `jiter::serde` and `serde_json`, asserting the two agree. Generation is constrained to the part
+// of the search space both parsers handle identically, sidestepping jiter's documented divergences:
+//   * integers are bounded to `i64`, so we never hit the `i128`/`u128`/`f64` widening that differs
+//     from serde_json's arbitrary-precision representation (covered by `big_integers`);
+//   * floats are always finite, so we never produce `NaN`/`Infinity` (covered by the `non_finite_*`
+//     and `nan_and_infinity_*` tests).
+
+use proptest::prelude::*;
+use serde_json::Value;
+
+/// Strategy for a finite `f64` (excludes `NaN`/`±Infinity`, which `Number::from_f64` rejects).
+fn finite_f64() -> impl Strategy<Value = f64> {
+    prop::num::f64::NORMAL | prop::num::f64::SUBNORMAL | prop::num::f64::ZERO
+}
+
+/// Strategy for an integer both parsers decode identically.
+///
+/// With `num-bigint` the full `i64` range works. Without it, jiter's decoder rejects integers of 19+
+/// digits even when they fit in `i64` (it accumulates in 18-digit chunks, then needs the bigint
+/// path), so we keep generation within ±10^18 to stay inside the shared search space.
+#[cfg(feature = "num-bigint")]
+fn json_int() -> impl Strategy<Value = i64> {
+    any::<i64>()
+}
+#[cfg(not(feature = "num-bigint"))]
+fn json_int() -> impl Strategy<Value = i64> {
+    -999_999_999_999_999_999_i64..=999_999_999_999_999_999_i64
+}
+
+/// Strategy for arbitrary JSON values both parsers agree on (see module note above).
+fn json_value() -> impl Strategy<Value = Value> {
+    let leaf = prop_oneof![
+        Just(Value::Null),
+        any::<bool>().prop_map(Value::Bool),
+        json_int().prop_map(|i| Value::Number(i.into())),
+        finite_f64().prop_map(|f| Value::Number(serde_json::Number::from_f64(f).unwrap())),
+        any::<String>().prop_map(Value::String),
+    ];
+    leaf.prop_recursive(5, 64, 10, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..10).prop_map(Value::Array),
+            prop::collection::hash_map(any::<String>(), inner, 0..10)
+                .prop_map(|m| Value::Object(m.into_iter().collect())),
+        ]
+    })
+}
+
+/// Compare two numbers by value rather than representation: with serde_json's `arbitrary_precision`
+/// a `Number` stores its source text, so `9.5` parsed by serde_json and the same `f64` round-tripped
+/// by jiter would compare unequal under `==` despite being the same number.
+fn number_eq(a: &serde_json::Number, b: &serde_json::Number) -> bool {
+    if let (Some(x), Some(y)) = (a.as_i64(), b.as_i64()) {
+        return x == y;
+    }
+    if let (Some(x), Some(y)) = (a.as_u64(), b.as_u64()) {
+        return x == y;
+    }
+    matches!((a.as_f64(), b.as_f64()), (Some(x), Some(y)) if x == y)
+}
+
+/// Structural equality with by-value number comparison (see [`number_eq`]).
+fn json_eq(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Null, Value::Null) => true,
+        (Value::Bool(x), Value::Bool(y)) => x == y,
+        (Value::String(x), Value::String(y)) => x == y,
+        (Value::Number(x), Value::Number(y)) => number_eq(x, y),
+        (Value::Array(x), Value::Array(y)) => x.len() == y.len() && x.iter().zip(y).all(|(a, b)| json_eq(a, b)),
+        (Value::Object(x), Value::Object(y)) => {
+            x.len() == y.len() && x.iter().all(|(k, v)| y.get(k).is_some_and(|w| json_eq(v, w)))
+        }
+        _ => false,
+    }
+}
+
+proptest! {
+    #[test]
+    fn proptest_matches_serde_json(value in json_value()) {
+        let json = serde_json::to_string(&value).unwrap();
+        let jiter: Value = from_str(&json).unwrap();
+        let serde: Value = serde_json::from_str(&json).unwrap();
+        prop_assert!(
+            json_eq(&jiter, &serde),
+            "mismatch for {json}\n  jiter: {jiter:?}\n  serde: {serde:?}"
+        );
+    }
 }

--- a/crates/jiter/tests/serde.rs
+++ b/crates/jiter/tests/serde.rs
@@ -1,0 +1,423 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use jiter::serde::{Error, JiterDeserializer, from_slice, from_str};
+
+fn de_f64_inf_nan(s: &str) -> f64 {
+    let mut de = JiterDeserializer::new(s.as_bytes()).with_allow_inf_nan();
+    let v = f64::deserialize(&mut de).unwrap();
+    de.finish().unwrap();
+    v
+}
+
+fn de_value_inf_nan(s: &str) -> serde_json::Value {
+    let mut de = JiterDeserializer::new(s.as_bytes()).with_allow_inf_nan();
+    let v = serde_json::Value::deserialize(&mut de).unwrap();
+    de.finish().unwrap();
+    v
+}
+
+#[test]
+fn primitives() {
+    assert!(from_str::<bool>("true").unwrap());
+    assert_eq!(from_str::<i64>("-42").unwrap(), -42);
+    assert_eq!(from_str::<u64>("42").unwrap(), 42);
+    assert!((from_str::<f64>("2.5").unwrap() - 2.5).abs() < f64::EPSILON);
+    assert_eq!(from_str::<String>(r#""hello""#).unwrap(), "hello");
+    assert_eq!(from_str::<Option<i64>>("null").unwrap(), None);
+    assert_eq!(from_str::<Option<i64>>("5").unwrap(), Some(5));
+    assert_eq!(from_str::<()>("null").unwrap(), ());
+}
+
+#[test]
+fn vecs_and_maps() {
+    assert_eq!(from_str::<Vec<i64>>("[1, 2, 3]").unwrap(), vec![1, 2, 3]);
+    assert_eq!(from_str::<Vec<i64>>("[]").unwrap(), Vec::<i64>::new());
+
+    let map: BTreeMap<String, i64> = from_str(r#"{"a": 1, "b": 2}"#).unwrap();
+    assert_eq!(map, BTreeMap::from([("a".to_string(), 1), ("b".to_string(), 2)]));
+
+    // integer keys (parsed from the key string)
+    let map: BTreeMap<u32, String> = from_str(r#"{"1": "one", "2": "two"}"#).unwrap();
+    assert_eq!(map, BTreeMap::from([(1, "one".to_string()), (2, "two".to_string())]));
+}
+
+#[derive(Deserialize, PartialEq, Debug)]
+struct Person<'a> {
+    name: &'a str,
+    age: u8,
+    phones: Vec<&'a str>,
+}
+
+#[test]
+fn borrowed_struct() {
+    let data = r#"{"name": "John Doe", "age": 43, "phones": ["+44 111", "+44 222"]}"#;
+    let person: Person = from_str(data).unwrap();
+    assert_eq!(
+        person,
+        Person {
+            name: "John Doe",
+            age: 43,
+            phones: vec!["+44 111", "+44 222"],
+        }
+    );
+}
+
+#[test]
+fn zero_copy_borrowed_str() {
+    // unescaped `&str` borrows from the input: the slice points inside the input buffer
+    let data = br#""no escapes here""#;
+    let s: &str = from_slice(data).unwrap();
+    assert_eq!(s, "no escapes here");
+    let input = data.as_ptr() as usize..(data.as_ptr() as usize + data.len());
+    assert!(
+        input.contains(&(s.as_ptr() as usize)),
+        "string should borrow from input"
+    );
+}
+
+#[test]
+fn escaped_string_is_owned() {
+    // escapes force decoding onto the tape; deserializing to an owned `String` works
+    let s: String = from_str(r#""tab\tnewline\n""#).unwrap();
+    assert_eq!(s, "tab\tnewline\n");
+}
+
+#[test]
+fn borrowed_str_with_escape_errors() {
+    // an escaped `&str` can't be borrowed (same as serde_json)
+    let err = from_str::<&str>(r#""has \t escape""#).unwrap_err();
+    assert!(matches!(err, Error::Data { .. }));
+}
+
+#[derive(Deserialize, PartialEq, Debug)]
+struct Nested {
+    inner: Inner,
+    list: Vec<Inner>,
+}
+
+#[derive(Deserialize, PartialEq, Debug)]
+struct Inner {
+    value: i64,
+}
+
+#[test]
+fn nested() {
+    let data = r#"{"inner": {"value": 1}, "list": [{"value": 2}, {"value": 3}]}"#;
+    let nested: Nested = from_str(data).unwrap();
+    assert_eq!(
+        nested,
+        Nested {
+            inner: Inner { value: 1 },
+            list: vec![Inner { value: 2 }, Inner { value: 3 }],
+        }
+    );
+}
+
+#[derive(Deserialize, PartialEq, Debug)]
+enum Shape {
+    Unit,
+    Newtype(i64),
+    Tuple(i64, i64),
+    Struct { x: i64, y: i64 },
+}
+
+#[test]
+fn enums() {
+    assert_eq!(from_str::<Shape>(r#""Unit""#).unwrap(), Shape::Unit);
+    assert_eq!(from_str::<Shape>(r#"{"Newtype": 7}"#).unwrap(), Shape::Newtype(7));
+    assert_eq!(from_str::<Shape>(r#"{"Tuple": [1, 2]}"#).unwrap(), Shape::Tuple(1, 2));
+    assert_eq!(
+        from_str::<Shape>(r#"{"Struct": {"x": 1, "y": 2}}"#).unwrap(),
+        Shape::Struct { x: 1, y: 2 }
+    );
+}
+
+#[derive(Deserialize, PartialEq, Debug)]
+struct Ordered {
+    a: i64,
+    b: String,
+    c: bool,
+    #[serde(default)]
+    d: Option<i64>,
+}
+
+#[test]
+fn field_order_independent() {
+    let declared = Ordered {
+        a: 1,
+        b: "two".to_string(),
+        c: true,
+        d: Some(4),
+    };
+
+    // declaration order
+    assert_eq!(
+        from_str::<Ordered>(r#"{"a": 1, "b": "two", "c": true, "d": 4}"#).unwrap(),
+        declared
+    );
+    // fully reversed order
+    assert_eq!(
+        from_str::<Ordered>(r#"{"d": 4, "c": true, "b": "two", "a": 1}"#).unwrap(),
+        declared
+    );
+    // shuffled, unknown fields interspersed, `d` omitted
+    let shuffled = r#"{"c": true, "x": [1, 2, 3], "b": "two", "y": {"z": null}, "a": 1}"#;
+    assert_eq!(
+        from_str::<Ordered>(shuffled).unwrap(),
+        Ordered {
+            a: 1,
+            b: "two".to_string(),
+            c: true,
+            d: None,
+        }
+    );
+}
+
+#[test]
+fn skips_unknown_fields() {
+    // unknown fields are skipped
+    let data = r#"{"value": 5, "unknown": [1, 2, {"deep": "nested"}], "more": null}"#;
+    let inner: Inner = from_str(data).unwrap();
+    assert_eq!(inner, Inner { value: 5 });
+}
+
+#[test]
+fn trailing_data_errors() {
+    assert!(from_str::<i64>("1 2").is_err());
+    assert!(from_str::<Vec<i64>>("[1, 2] extra").is_err());
+}
+
+#[test]
+fn wrong_type_errors() {
+    let err = from_str::<i64>(r#""not a number""#).unwrap_err();
+    // string where i64 expected
+    assert!(matches!(err, Error::Data { .. }));
+}
+
+#[test]
+fn type_error_carries_real_position() {
+    #[derive(Deserialize, Debug)]
+    #[allow(dead_code)]
+    struct S {
+        a: i64,
+        b: i64,
+    }
+    // the error points at the offending value, not index 0
+    let data = r#"{"a": 1, "b": "oops"}"#;
+    let err = from_str::<S>(data).unwrap_err();
+    assert!(matches!(err, Error::Data { .. }));
+    assert_eq!(err.index(), Some(data.find("\"oops\"").unwrap()));
+}
+
+#[test]
+fn error_resolves_to_line_and_column() {
+    #[derive(Deserialize, Debug)]
+    #[allow(dead_code)]
+    struct S {
+        a: i64,
+        b: i64,
+    }
+    // error on line 3 resolves to a line/column
+    let data = "{\n  \"a\": 1,\n  \"b\": \"oops\"\n}";
+    let err = from_str::<S>(data).unwrap_err();
+    let pos = err.get_position(data.as_bytes()).unwrap();
+    assert_eq!(pos.line, 3);
+    assert!(err.description(data.as_bytes()).contains("line 3 column"));
+}
+
+#[test]
+fn from_slice_works() {
+    let v: Vec<u8> = from_slice(b"[1, 2, 3]").unwrap();
+    assert_eq!(v, vec![1, 2, 3]);
+}
+
+#[test]
+fn recursion_limit_default_rejects_deep_nesting() {
+    // beyond the default limit: a clean error, not a stack overflow
+    let deep = format!("{}{}", "[".repeat(300), "]".repeat(300));
+    let err = from_str::<serde_json::Value>(&deep).unwrap_err();
+    assert!(matches!(&err, Error::Syntax(e) if e.error_type == jiter::JsonErrorType::RecursionLimitExceeded));
+}
+
+#[test]
+fn recursion_limit_configurable() {
+    let json = "[[[[[1]]]]]"; // 5 levels deep
+    let mut de = JiterDeserializer::new(json.as_bytes()).with_recursion_limit(3);
+    assert!(serde_json::Value::deserialize(&mut de).is_err());
+
+    let mut de = JiterDeserializer::new(json.as_bytes()).with_recursion_limit(10);
+    assert!(serde_json::Value::deserialize(&mut de).is_ok());
+}
+
+#[test]
+fn recursion_limit_disabled_allows_deep_nesting() {
+    // 300 levels exceeds the default of 200; disabling the limit deserializes it
+    let deep = format!("{}1{}", "[".repeat(300), "]".repeat(300));
+    let mut de = JiterDeserializer::new(deep.as_bytes()).disable_recursion_limit();
+    assert!(serde_json::Value::deserialize(&mut de).is_ok());
+    de.finish().unwrap();
+}
+
+#[test]
+fn extra_tuple_elements_rejected() {
+    // too many elements is an error, matching serde_json
+    assert_eq!(from_str::<(i64, i64)>("[1, 2]").unwrap(), (1, 2));
+    assert!(from_str::<(i64, i64)>("[1, 2, 3]").is_err());
+    assert!(from_str::<[i64; 2]>("[1, 2, 3]").is_err());
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+enum Tree {
+    Leaf,
+    Node(Box<Tree>),
+}
+
+#[test]
+fn recursion_limit_counts_enum_wrappers() {
+    let nested = r#"{"Node":{"Node":{"Node":"Leaf"}}}"#; // 3 nested Node objects
+    // each enum wrapper counts toward the limit
+    let mut de = JiterDeserializer::new(nested.as_bytes()).with_recursion_limit(2);
+    assert!(Tree::deserialize(&mut de).is_err());
+    // a generous limit accepts it
+    let mut de = JiterDeserializer::new(nested.as_bytes()).with_recursion_limit(10);
+    assert!(Tree::deserialize(&mut de).is_ok());
+}
+
+#[test]
+fn unit_variant_object_form() {
+    // serde_json accepts `{"Unit": null}` for a unit variant
+    assert_eq!(from_str::<Shape>(r#"{"Unit": null}"#).unwrap(), Shape::Unit);
+    // the bare-string form still works
+    assert_eq!(from_str::<Shape>(r#""Unit""#).unwrap(), Shape::Unit);
+    // non-null content for a unit variant is rejected
+    assert!(from_str::<Shape>(r#"{"Unit": 5}"#).is_err());
+}
+
+#[test]
+fn recursion_limit_applies_to_skipped_fields() {
+    #[derive(Deserialize, Debug)]
+    #[allow(dead_code)]
+    struct S {
+        keep: i64,
+    }
+    // a deeply-nested skipped field hits the limit; disabling it accepts it (up to the skip ceiling)
+    let deep = format!(r#"{{"skip": {}1{}, "keep": 5}}"#, "[".repeat(230), "]".repeat(230));
+    assert!(from_str::<S>(&deep).is_err());
+
+    let mut de = JiterDeserializer::new(deep.as_bytes()).disable_recursion_limit();
+    assert_eq!(S::deserialize(&mut de).unwrap().keep, 5);
+}
+
+#[test]
+fn big_integers() {
+    // fits in i128 but not i64
+    let n: i128 = from_str("170141183460469231731687303715884105727").unwrap();
+    assert_eq!(n, i128::MAX);
+
+    // largest u128
+    let n: u128 = from_str("340282366920938463463374607431768211455").unwrap();
+    assert_eq!(n, u128::MAX);
+
+    // exceeds i64 -> error when the target is i64
+    assert!(from_str::<i64>("99999999999999999999999999999999").is_err());
+
+    // bigger than u128 -> falls back to f64 (lossy), still deserializes as a float
+    let huge = format!("1{}", "0".repeat(40)); // 1e40
+    let f: f64 = from_str(&huge).unwrap();
+    assert!((f - 1e40).abs() / 1e40 < 1e-10);
+}
+
+#[test]
+fn big_floats() {
+    let big: f64 = from_str("1e308").unwrap();
+    assert!(big > 1e307 && big.is_finite());
+
+    let small: f64 = from_str("1e-308").unwrap();
+    assert!(small > 0.0 && small < 1e-307);
+
+    // a long fractional literal round-trips to the nearest f64
+    let pi: f64 = from_str("3.141592653589793238462643383279").unwrap();
+    assert!((pi - std::f64::consts::PI).abs() < 1e-15);
+}
+
+#[test]
+fn nan_and_infinity_rejected_by_default() {
+    // not valid JSON unless explicitly allowed (matches serde_json)
+    assert!(from_str::<f64>("NaN").is_err());
+    assert!(from_str::<f64>("Infinity").is_err());
+    assert!(from_str::<f64>("-Infinity").is_err());
+}
+
+#[test]
+fn nan_and_infinity_allowed_when_enabled() {
+    assert!(de_f64_inf_nan("NaN").is_nan());
+
+    let inf = de_f64_inf_nan("Infinity");
+    assert!(inf.is_infinite() && inf.is_sign_positive());
+
+    let ninf = de_f64_inf_nan("-Infinity");
+    assert!(ninf.is_infinite() && ninf.is_sign_negative());
+}
+
+#[test]
+fn non_finite_into_value_becomes_string() {
+    use serde_json::Value;
+    // `serde_json::Value` can't hold non-finite floats; preserved as strings, not dropped to `Null`
+    assert_eq!(de_value_inf_nan("Infinity"), Value::String("Infinity".into()));
+    assert_eq!(de_value_inf_nan("-Infinity"), Value::String("-Infinity".into()));
+    assert_eq!(de_value_inf_nan("NaN"), Value::String("NaN".into()));
+    // ordinary floats remain numbers
+    assert_eq!(de_value_inf_nan("2.5"), Value::from(2.5));
+}
+
+#[test]
+fn non_finite_into_f64_keeps_real_value() {
+    // typed f64 keeps the real non-finite value
+    #[derive(Deserialize)]
+    struct S {
+        x: f64,
+        y: f64,
+    }
+    let mut de = JiterDeserializer::new(br#"{"x": Infinity, "y": NaN}"#).with_allow_inf_nan();
+    let s = S::deserialize(&mut de).unwrap();
+    de.finish().unwrap();
+    assert!(s.x.is_infinite() && s.x.is_sign_positive());
+    assert!(s.y.is_nan());
+}
+
+#[test]
+fn overflow_into_value_no_longer_null() {
+    // 1e400 overflows to inf; into `Value` it becomes a string
+    let v: serde_json::Value = from_str("1e400").unwrap();
+    assert_eq!(v, serde_json::Value::String("Infinity".into()));
+    // into a typed f64 it's the real infinity
+    let f: f64 = from_str("1e400").unwrap();
+    assert!(f.is_infinite());
+}
+
+#[test]
+fn matches_serde_json() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Doc {
+        id: u64,
+        title: String,
+        tags: Vec<String>,
+        active: bool,
+        score: f64,
+        meta: Option<BTreeMap<String, String>>,
+    }
+    let data = r#"
+        {
+            "id": 12345,
+            "title": "A \"quoted\" title",
+            "tags": ["a", "b", "c"],
+            "active": true,
+            "score": 9.5,
+            "meta": {"k": "v"}
+        }"#;
+    let from_jiter: Doc = from_str(data).unwrap();
+    let from_serde: Doc = serde_json::from_str(data).unwrap();
+    assert_eq!(from_jiter, from_serde);
+}


### PR DESCRIPTION
This adds a new `serde` feature that allows us to use `jiter` to deserialize structs/objects in rust.  Currently does not support `Serialize` but could possibly be added in later.

The reason I need this is so we can support this in logfire ingest, there are a handful of structs we need to deserialize from JSON, and the `serde_json` parser does not support `Infinity` and `NaN` identifiers that python natively produces for JSON (even if it's invalid JSON).

I've tried to keep this pretty self contained and reuse as much as possible.