### PR TITLE
Compare jiter with `serde_json` over the `json-cases` corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
+      - run: uv run crates/jiter/benches/generate_big.py
+
         # since not all benchmarks are run with codspeed, we test them all there
       - run: cargo bench -p jiter -- --test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: samuelcolvin/json-cases
+          ref: fa6c17fbabf775b8099a0ed5f32cfc733700cedc # 2026-08-19, `size` and `tags` in cases.json
           path: json-cases
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
 
 permissions: {}
 
+env:
+  # the json-cases corpus the json_cases test and benchmark run over; pinned so that a commit there
+  # can't turn this repository's CI red, and so the benchmark numbers stay comparable between runs
+  JSON_CASES_REF: fa6c17fbabf775b8099a0ed5f32cfc733700cedc # 2026-08-19, `size` and `tags` in cases.json
+
 jobs:
   resolve:
     runs-on: ubuntu-latest
@@ -82,7 +87,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: samuelcolvin/json-cases
-          ref: fa6c17fbabf775b8099a0ed5f32cfc733700cedc # 2026-08-19, `size` and `tags` in cases.json
+          ref: ${{ env.JSON_CASES_REF }}
           path: json-cases
           persist-credentials: false
 
@@ -179,6 +184,12 @@ jobs:
 
   bench:
     runs-on: ubuntu-latest
+
+    env:
+      # the corpus the json_cases benchmarks run over, checked out and built below; without it they
+      # register nothing and CodSpeed sees only the benchmarks in main.rs
+      JSON_CASES: ${{ github.workspace }}/json-cases
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -189,6 +200,14 @@ jobs:
           python-version: '3.13'
           enable-cache: true # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
 
+      - name: check out the json-cases corpus
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: samuelcolvin/json-cases
+          ref: ${{ env.JSON_CASES_REF }}
+          path: json-cases
+          persist-credentials: false
+
       - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           channel: stable
@@ -196,6 +215,10 @@ jobs:
           bins: cargo-codspeed
 
       - run: uv run crates/jiter/benches/generate_big.py
+
+      # cases/ and cases.json are gitignored build artifacts, so a fresh checkout has to build them
+      - name: build the json-cases corpus
+        run: make -C json-cases build
 
       - run: cargo codspeed build -F python -p jiter
 
@@ -227,8 +250,6 @@ jobs:
       # project; every other job builds against the committed Cargo.lock
       - run: rm Cargo.lock
 
-      # this job is about resolving dependencies fresh, which the json_cases tests say nothing
-      # about, so they are skipped here rather than building the corpus again
       - run: cargo test -F python
         env:
           RUST_BACKTRACE: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
     env:
       RUNS_ON: ${{ matrix.runs-on }}-latest
       RUST_VERSION: ${{ matrix.rust-version }}
+      # the corpus the json_cases tests run over, checked out and built below
+      JSON_CASES: ${{ github.workspace }}/json-cases
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -75,6 +77,24 @@ jobs:
       - uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: cargo-llvm-cov
+
+      - name: check out the json-cases corpus
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: samuelcolvin/json-cases
+          path: json-cases
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: false # the corpus generator has no dependencies, there is nothing to cache
+
+      # cases/ and cases.json are gitignored build artifacts, so a fresh checkout has to build
+      # them; the indexer is a separate crate, built with stable rather than this job's toolchain
+      - name: build the json-cases corpus
+        run: make -C json-cases build
+        env:
+          RUSTUP_TOOLCHAIN: stable
 
       - name: install cargo-careful
         if: matrix.rust-version == 'nightly'
@@ -206,9 +226,12 @@ jobs:
       # project; every other job builds against the committed Cargo.lock
       - run: rm Cargo.lock
 
+      # this job is about resolving dependencies fresh, which the json_cases tests say nothing
+      # about, so they are skipped here rather than building the corpus again
       - run: cargo test -F python
         env:
           RUST_BACKTRACE: 1
+          JSON_CASES_SKIP: '1'
 
   fuzz:
     name: fuzz on ${{ matrix.runs-on }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,11 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
+        # since not all benchmarks are run with codspeed, we test them all there
+      - run: cargo bench -p jiter -- --test
+        env:
+          RUST_BACKTRACE: 1
+
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           env_vars: RUNS_ON,RUST_VERSION

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/jiter", "crates/jiter-python"]
-exclude = ["crates/fuzz"]
+exclude = ["crates/fuzz", "json-cases/check/rust"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/jiter/Cargo.toml
+++ b/crates/jiter/Cargo.toml
@@ -56,6 +56,10 @@ name = "main"
 harness = false
 
 [[bench]]
+name = "json_cases"
+harness = false
+
+[[bench]]
 name = "python"
 required-features = ["python"]
 harness = false

--- a/crates/jiter/Cargo.toml
+++ b/crates/jiter/Cargo.toml
@@ -68,6 +68,10 @@ harness = false
 [package.metadata.docs.rs]
 all-features = true
 
+[lints.rust]
+# set by cargo-codspeed; the serde benchmarks are compiled out under it
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(codspeed)'] }
+
 [lints.clippy]
 dbg_macro = "deny"
 print_stdout = "deny"

--- a/crates/jiter/benches/README.md
+++ b/crates/jiter/benches/README.md
@@ -37,6 +37,10 @@ string bytes for `escapes` and `non-ascii`), so the sets are the documents a par
 spend that time on; documents carry several tags, so the sets overlap and add up to more than the
 corpus.
 
+Every benchmark is paired with serde_json for local comparison, but those halves are compiled out
+under `cfg(codspeed)`: CodSpeed tracks jiter's own history, and serde_json is pinned in
+`Cargo.lock`, so timing it there costs instrumentation time for a line that doesn't move.
+
 `cases/` is generated, so the numbers are only comparable between runs over the same revision of the
 corpus — regenerating it with a different `json-cases` changes the workload itself. CI therefore
 pins the corpus (`JSON_CASES_REF` in `.github/workflows/ci.yml`) for the CodSpeed run; bumping that

--- a/crates/jiter/benches/README.md
+++ b/crates/jiter/benches/README.md
@@ -11,3 +11,32 @@ To run benchmarks, run:
 ```shell
 cargo bench -p jiter
 ```
+
+## The json-cases corpus
+
+`json_cases.rs` is a second benchmark target that parses the whole
+[`json-cases`](https://github.com/samuelcolvin/json-cases) corpus — ~2800 documents, most of them
+small and over half of them malformed — one iteration per pass over the lot. It complements the
+benchmarks in `main.rs`, each of which is one large well formed document of a single shape: this is
+the only one that measures the error paths, and the only one whose per-document overhead shows up.
+
+The corpus is a separate checkout, so the benchmark registers nothing at all when it isn't there:
+
+```shell
+git clone https://github.com/samuelcolvin/json-cases ../json-cases
+make -C ../json-cases build              # writes cases/ and cases.json
+cargo bench -p jiter --bench json_cases  # or JSON_CASES=/path/to/json-cases cargo bench ...
+```
+
+It reports the corpus as a whole (`json_cases_all_*`) and then one benchmark per tag from
+`cases.json` — `json_cases_strings_*`, `json_cases_escapes_*`, `json_cases_ints_*`,
+`json_cases_deep_*`, `json_cases_error_*` and so on — which is what says roughly where a change
+landed: the string scanner, number decoding, the recursion, the whitespace loop or the failure
+path. A tag is only set when that class holds a quarter of the document's bytes (a tenth of its
+string bytes for `escapes` and `non-ascii`), so the sets are the documents a parser would really
+spend that time on; documents carry several tags, so the sets overlap and add up to more than the
+corpus.
+
+`cases/` is generated, so the numbers are only comparable between runs over the same revision of the
+corpus — regenerating it with a different `json-cases` changes the workload itself, which is also
+why this isn't part of the CodSpeed run in CI.

--- a/crates/jiter/benches/README.md
+++ b/crates/jiter/benches/README.md
@@ -38,5 +38,6 @@ spend that time on; documents carry several tags, so the sets overlap and add up
 corpus.
 
 `cases/` is generated, so the numbers are only comparable between runs over the same revision of the
-corpus — regenerating it with a different `json-cases` changes the workload itself, which is also
-why this isn't part of the CodSpeed run in CI.
+corpus — regenerating it with a different `json-cases` changes the workload itself. CI therefore
+pins the corpus (`JSON_CASES_REF` in `.github/workflows/ci.yml`) for the CodSpeed run; bumping that
+pin moves every `json_cases_*` number at once, independently of anything jiter did.

--- a/crates/jiter/benches/json_cases.rs
+++ b/crates/jiter/benches/json_cases.rs
@@ -1,0 +1,103 @@
+//! Parse the [`json-cases`](https://github.com/samuelcolvin/json-cases) corpus, the same documents
+//! the `json_cases` test compares against serde_json. Every file is read into memory first, then
+//! one iteration parses a whole set of them into values and swallows the errors, so unlike the
+//! benchmarks in `main.rs` — each a single well formed document of one shape — this measures a
+//! mixed workload of many documents, most of them small, over half of them malformed. It is the
+//! only benchmark here that exercises the error paths.
+//!
+//! The corpus is timed once as a whole and then once per [`TAGS`] tag, which is what says roughly
+//! where a change landed: `strings` and `escapes` move with the string scanner, `ints`/`floats`
+//! with number decoding, `deep` with the recursion, `whitespace` with the between-token loop, and
+//! `error` with the failure path. A document carries several tags, so the sets overlap and add up
+//! to more than the corpus.
+//!
+//! The corpus is a separate checkout, see [`corpus`]; when it isn't there this registers no
+//! benchmarks at all and `cargo bench` just runs the rest.
+//!
+//! ```bash
+//! git clone https://github.com/samuelcolvin/json-cases ../json-cases
+//! make -C ../json-cases build              # writes cases/ and cases.json
+//! cargo bench -p jiter --bench json_cases  # or JSON_CASES=/path/to/json-cases cargo bench ...
+//! ```
+//!
+//! `cases/` is generated, so these numbers are only comparable between runs over the same revision
+//! of the corpus: regenerating it with a different `json-cases` changes the workload itself.
+#![allow(clippy::print_stdout)]
+
+use std::hint::black_box;
+
+use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
+
+use jiter::JsonValue;
+use serde_json::Value as SerdeValue;
+
+#[path = "../tests/corpus/mod.rs"]
+mod corpus;
+
+use corpus::{TAGS, find_corpus_root, load_cases};
+
+/// Parse every document with jiter, counting the ones that parsed — the malformed documents are
+/// part of the workload, an error is a result like any other.
+fn jiter_value(documents: &[&[u8]]) -> usize {
+    let mut parsed = 0;
+    for json_data in documents {
+        if let Ok(value) = JsonValue::parse(black_box(json_data), false) {
+            black_box(&value);
+            parsed += 1;
+        }
+    }
+    parsed
+}
+
+/// The same with serde_json, for comparison. Note that this crate's dev-dependency on serde_json
+/// turns on `arbitrary_precision`, `preserve_order` and `float_roundtrip`, as the benchmarks in
+/// `main.rs` do.
+fn serde_value(documents: &[&[u8]]) -> usize {
+    let mut parsed = 0;
+    for json_data in documents {
+        if let Ok(value) = serde_json::from_slice::<SerdeValue>(black_box(json_data)) {
+            black_box(&value);
+            parsed += 1;
+        }
+    }
+    parsed
+}
+
+fn corpus_benches(c: &mut Criterion) {
+    let Some(root) = find_corpus_root() else {
+        println!("json-cases corpus not found, registering no benchmarks (see the module docs)");
+        return;
+    };
+    let cases = load_cases(&root);
+
+    // the whole corpus first, then the documents behind each tag, so a change can be traced to the
+    // part of the parser that caused it rather than just to the total
+    let all: Vec<&[u8]> = cases.iter().map(|case| case.json_data.as_slice()).collect();
+    let mut groups: Vec<(&str, Vec<&[u8]>)> = vec![("all", all)];
+    for tag in TAGS {
+        let documents: Vec<&[u8]> = cases
+            .iter()
+            .filter(|case| case.tags.iter().any(|case_tag| case_tag == tag))
+            .map(|case| case.json_data.as_slice())
+            .collect();
+        assert!(
+            !documents.is_empty(),
+            "no cases tagged {tag}, is the corpus up to date? run `make build` in it"
+        );
+        groups.push((tag, documents));
+    }
+
+    for (name, documents) in &groups {
+        let bytes: usize = documents.iter().map(|json_data| json_data.len()).sum();
+        println!("json_cases_{name}: {} documents, {} bytes", documents.len(), bytes);
+        c.bench_function(&format!("json_cases_{name}_jiter_value"), |bench| {
+            bench.iter(|| black_box(jiter_value(documents)));
+        });
+        c.bench_function(&format!("json_cases_{name}_serde_value"), |bench| {
+            bench.iter(|| black_box(serde_value(documents)));
+        });
+    }
+}
+
+criterion_group!(benches, corpus_benches);
+criterion_main!(benches);

--- a/crates/jiter/benches/json_cases.rs
+++ b/crates/jiter/benches/json_cases.rs
@@ -1,27 +1,8 @@
-//! Parse the [`json-cases`](https://github.com/samuelcolvin/json-cases) corpus, the same documents
-//! the `json_cases` test compares against serde_json. Every file is read into memory first, then
-//! one iteration parses a whole set of them into values and swallows the errors, so unlike the
-//! benchmarks in `main.rs` — each a single well formed document of one shape — this measures a
-//! mixed workload of many documents, most of them small, over half of them malformed. It is the
-//! only benchmark here that exercises the error paths.
-//!
-//! The corpus is timed once as a whole and then once per [`TAGS`] tag, which is what says roughly
-//! where a change landed: `strings` and `escapes` move with the string scanner, `ints`/`floats`
-//! with number decoding, `deep` with the recursion, `whitespace` with the between-token loop, and
-//! `error` with the failure path. A document carries several tags, so the sets overlap and add up
-//! to more than the corpus.
-//!
-//! The corpus is a separate checkout, see [`corpus`]; when it isn't there this registers no
-//! benchmarks at all and `cargo bench` just runs the rest.
-//!
-//! ```bash
-//! git clone https://github.com/samuelcolvin/json-cases ../json-cases
-//! make -C ../json-cases build              # writes cases/ and cases.json
-//! cargo bench -p jiter --bench json_cases  # or JSON_CASES=/path/to/json-cases cargo bench ...
-//! ```
-//!
-//! `cases/` is generated, so these numbers are only comparable between runs over the same revision
-//! of the corpus: regenerating it with a different `json-cases` changes the workload itself.
+//! Parse the json-cases corpus, once as a whole and once per [`TAGS`] tag — which is what says
+//! roughly where a change landed, `strings` with the string scanner, `deep` with the recursion,
+//! `error` with the failure path. Documents carry several tags, so the sets overlap. See
+//! [`corpus`] for the checkout, which this skips entirely when it isn't there; the numbers only
+//! compare between runs over the same revision of it, `cases/` being generated.
 #![allow(clippy::print_stdout)]
 
 use std::hint::black_box;

--- a/crates/jiter/benches/json_cases.rs
+++ b/crates/jiter/benches/json_cases.rs
@@ -10,6 +10,7 @@ use std::hint::black_box;
 use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
 
 use jiter::JsonValue;
+#[cfg(not(codspeed))]
 use serde_json::Value as SerdeValue;
 
 #[path = "../tests/corpus/mod.rs"]
@@ -32,7 +33,8 @@ fn jiter_value(documents: &[&[u8]]) -> usize {
 
 /// The same with serde_json, for comparison. Note that this crate's dev-dependency on serde_json
 /// turns on `arbitrary_precision`, `preserve_order` and `float_roundtrip`, as the benchmarks in
-/// `main.rs` do.
+/// `main.rs` do. CodSpeed tracks jiter's own history, so this is left out of it.
+#[cfg(not(codspeed))]
 fn serde_value(documents: &[&[u8]]) -> usize {
     let mut parsed = 0;
     for json_data in documents {
@@ -74,6 +76,7 @@ fn corpus_benches(c: &mut Criterion) {
         c.bench_function(&format!("json_cases_{name}_jiter_value"), |bench| {
             bench.iter(|| black_box(jiter_value(documents)));
         });
+        #[cfg(not(codspeed))]
         c.bench_function(&format!("json_cases_{name}_serde_value"), |bench| {
             bench.iter(|| black_box(serde_value(documents)));
         });

--- a/crates/jiter/benches/main.rs
+++ b/crates/jiter/benches/main.rs
@@ -6,6 +6,9 @@ use std::io::Read;
 use std::path::Path;
 
 use jiter::{Jiter, JsonValue, PartialMode, Peek};
+// serde_json is the local comparison baseline; CodSpeed tracks jiter's own history, so the serde
+// benchmarks are left out of it, as monty leaves its CPython benchmarks out of CI
+#[cfg(not(codspeed))]
 use serde_json::Value;
 
 fn read_title(path: &str) -> String {
@@ -219,6 +222,10 @@ fn jiter_string(path: &str, c: &mut Criterion) {
     });
 }
 
+#[cfg(codspeed)]
+fn serde_value(_path: &str, _c: &mut Criterion) {}
+
+#[cfg(not(codspeed))]
 fn serde_value(path: &str, c: &mut Criterion) {
     let title = read_title(path) + "_serde_value";
     let json = read_file(path);
@@ -232,6 +239,10 @@ fn serde_value(path: &str, c: &mut Criterion) {
     });
 }
 
+#[cfg(codspeed)]
+fn serde_str(_path: &str, _c: &mut Criterion) {}
+
+#[cfg(not(codspeed))]
 fn serde_str(path: &str, c: &mut Criterion) {
     let title = read_title(path) + "_serde_iter";
     let json = read_file(path);

--- a/crates/jiter/tests/corpus/mod.rs
+++ b/crates/jiter/tests/corpus/mod.rs
@@ -1,17 +1,8 @@
 //! Loading the [`json-cases`](https://github.com/samuelcolvin/json-cases) corpus, shared by the
-//! `json_cases` test and the `json_cases` benchmark — each uses a subset of what is here.
-//!
-//! The corpus is a separate checkout whose `cases/` directory is a build artifact.
-//! `../json-cases` next to this repository is used by default, `JSON_CASES` overrides it:
-//!
-//! ```bash
-//! git clone https://github.com/samuelcolvin/json-cases ../json-cases
-//! make -C ../json-cases build              # writes cases/ and cases.json
-//! ```
-//!
-//! The tests require it: a corpus that isn't there fails them rather than skipping them, so that a
-//! checkout without it can't quietly pass the suite. `JSON_CASES_SKIP` is the way to opt out where
-//! building the corpus isn't worth it — CI sets it on the job that resolves fresh dependencies.
+//! `json_cases` test and benchmark. `cases/` is a build artifact, so a checkout has to be built
+//! with `make build`; `../json-cases` is used by default, `JSON_CASES` overrides it. The tests
+//! require it, failing rather than skipping when it is absent so a checkout without it can't
+//! quietly pass; `JSON_CASES_SKIP` opts out, as CI does where building it isn't worth it.
 #![allow(dead_code, clippy::print_stdout)]
 
 use std::path::{Path, PathBuf};

--- a/crates/jiter/tests/corpus/mod.rs
+++ b/crates/jiter/tests/corpus/mod.rs
@@ -1,0 +1,136 @@
+//! Loading the [`json-cases`](https://github.com/samuelcolvin/json-cases) corpus, shared by the
+//! `json_cases` test and the `json_cases` benchmark — each uses a subset of what is here.
+//!
+//! The corpus is a separate checkout whose `cases/` directory is a build artifact.
+//! `../json-cases` next to this repository is used by default, `JSON_CASES` overrides it:
+//!
+//! ```bash
+//! git clone https://github.com/samuelcolvin/json-cases ../json-cases
+//! make -C ../json-cases build              # writes cases/ and cases.json
+//! ```
+//!
+//! The tests require it: a corpus that isn't there fails them rather than skipping them, so that a
+//! checkout without it can't quietly pass the suite. `JSON_CASES_SKIP` is the way to opt out where
+//! building the corpus isn't worth it — CI sets it on the job that resolves fresh dependencies.
+#![allow(dead_code, clippy::print_stdout)]
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// One entry of `cases.json`. The index also records the error serde_json gave when it was
+/// written; that is ignored here, the test runs its own copy of serde_json instead.
+#[derive(Deserialize)]
+struct Case {
+    /// absolute path, valid only in the checkout that generated the index
+    path: String,
+    /// the top level directory under `cases/`
+    category: String,
+    /// what the document is made of, see [`TAGS`]
+    #[serde(default)]
+    tags: Vec<String>,
+    /// the other files holding this same document in a different spelling, recorded on one member
+    /// of each group so that following it from every entry visits each group once
+    #[serde(default)]
+    similar: Vec<String>,
+}
+
+/// A case with its content read, and its paths re-rooted at this checkout.
+pub struct Loaded {
+    /// path relative to the corpus root, doubling as the name to report the case by
+    pub name: String,
+    pub json_data: Vec<u8>,
+    pub category: String,
+    /// what the document is made of, see [`TAGS`]
+    pub tags: Vec<String>,
+    /// the `name`s of the other members of this case's group, see [`Case::similar`]
+    pub similar: Vec<String>,
+}
+
+/// The `json-cases` checkout, or `None` if it hasn't been cloned and built.
+pub fn find_corpus_root() -> Option<PathBuf> {
+    let root = match std::env::var_os("JSON_CASES") {
+        Some(dir) => PathBuf::from(dir),
+        None => Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../json-cases"),
+    };
+    root.join("cases.json").is_file().then_some(root)
+}
+
+/// The `json-cases` checkout to run the tests over, or `None` if `JSON_CASES_SKIP` is set to
+/// something non-empty; without it a missing corpus panics rather than skipping.
+pub fn corpus_root() -> Option<PathBuf> {
+    if std::env::var_os("JSON_CASES_SKIP").is_some_and(|skip| !skip.is_empty()) {
+        println!("JSON_CASES_SKIP is set, skipping");
+        return None;
+    }
+    Some(find_corpus_root().unwrap_or_else(|| {
+        panic!(
+            "the json-cases corpus is missing, the tests need it:\n\
+             \x20   git clone https://github.com/samuelcolvin/json-cases ../json-cases\n\
+             \x20   make -C ../json-cases build\n\
+             or point JSON_CASES at an existing checkout; `cases.json` was looked for under {}",
+            std::env::var_os("JSON_CASES").map_or_else(
+                || "../json-cases, next to this repository".to_string(),
+                |dir| dir.to_string_lossy().into_owned()
+            )
+        )
+    }))
+}
+
+/// `cases.json` holds absolute paths, valid only in the checkout that generated it, so re-root
+/// them; the result doubles as the name to report a case by.
+fn relative(root: &Path, path: &str) -> String {
+    if let Ok(rel) = Path::new(path).strip_prefix(root) {
+        return rel.to_string_lossy().into_owned();
+    }
+    match path.find("/cases/") {
+        Some(index) => path[index + 1..].to_string(),
+        None => path.to_string(),
+    }
+}
+
+/// Every case in the index, with its content read into memory.
+pub fn load_cases(root: &Path) -> Vec<Loaded> {
+    let index = std::fs::read(root.join("cases.json")).unwrap();
+    let cases: Vec<Case> = serde_json::from_slice(&index).unwrap();
+    assert!(!cases.is_empty(), "cases.json is empty, run `make build` in the corpus");
+    cases
+        .into_iter()
+        .map(|case| {
+            let name = relative(root, &case.path);
+            let json_data = std::fs::read(root.join(&name))
+                .unwrap_or_else(|e| panic!("{name}: {e}, run `make build` in the corpus"));
+            let similar = case.similar.iter().map(|path| relative(root, path)).collect();
+            Loaded {
+                name,
+                json_data,
+                category: case.category,
+                tags: case.tags,
+                similar,
+            }
+        })
+        .collect()
+}
+
+/// The `tags` the index uses, in the order the benchmark reports them.
+///
+/// A tag names a lexical class that holds at least a quarter of the document's bytes — a tenth of
+/// its *string* bytes for `escapes` and `non-ascii`, since the escape-free fast path is a fork
+/// inside the string scanner rather than a share of the file — so it says what a parser would
+/// spend its time on rather than what the document merely contains. `deep` is nesting of 20
+/// levels or more, and `error` is a verdict rather than a shape: no conforming parser accepts the
+/// document. Documents carry several, and `cases.json` describes them in full.
+pub const TAGS: [&str; 12] = [
+    "strings",
+    "escapes",
+    "non-ascii",
+    "numbers",
+    "ints",
+    "floats",
+    "constants",
+    "arrays",
+    "objects",
+    "deep",
+    "whitespace",
+    "error",
+];

--- a/crates/jiter/tests/json_cases.rs
+++ b/crates/jiter/tests/json_cases.rs
@@ -1,21 +1,8 @@
-//! Compare `jiter` with `serde_json` over the [`json-cases`](https://github.com/samuelcolvin/json-cases)
-//! corpus: every document is parsed by both, and the two must agree on whether it is valid JSON
-//! and, when it is, on the value it decodes to. The handful of places they legitimately differ are
-//! listed in [`known_difference`]; any other divergence fails the test.
-//!
-//! The corpus also groups documents that are one another's re-spellings — the same document
-//! indented, or with its strings escaped differently — under the `similar` key of `cases.json`;
-//! [`similar_cases_agree`] holds jiter to what that promises, that every member of a group decodes
-//! to the same value, or that they are all rejected.
-//!
-//! The corpus is a separate checkout, loaded by [`corpus`]; these tests skip themselves when it is
-//! not there:
-//!
-//! ```bash
-//! git clone https://github.com/samuelcolvin/json-cases ../json-cases
-//! make -C ../json-cases build              # writes cases/ and cases.json
-//! cargo test --test json_cases             # or JSON_CASES=/path/to/json-cases cargo test ...
-//! ```
+//! Compare `jiter` with `serde_json` over the json-cases corpus: the two must agree on whether
+//! each document is valid JSON and on the value it decodes to, bar the differences
+//! [`known_difference`] lists. [`similar_cases_agree`] separately holds jiter to the corpus's
+//! `similar` groups, one document spelled several ways: every member decodes to the same value, or
+//! they are all rejected. See [`corpus`] for the checkout these need.
 // floats are compared exactly on purpose, see `numbers_equal`
 #![allow(clippy::float_cmp, clippy::print_stdout)]
 

--- a/crates/jiter/tests/json_cases.rs
+++ b/crates/jiter/tests/json_cases.rs
@@ -1,0 +1,355 @@
+//! Compare `jiter` with `serde_json` over the [`json-cases`](https://github.com/pydantic/json-cases)
+//! corpus: every document is parsed by both, and the two must agree on whether it is valid JSON
+//! and, when it is, on the value it decodes to. The handful of places they legitimately differ are
+//! listed in [`known_difference`]; any other divergence fails the test.
+//!
+//! `json-cases` is a separate checkout whose `cases/` directory is a build artifact, so these tests
+//! skip themselves when the corpus is not there. `../json-cases` next to this repository is used by
+//! default, `JSON_CASES` overrides it:
+//!
+//! ```bash
+//! git clone https://github.com/pydantic/json-cases ../json-cases
+//! make -C ../json-cases build              # writes cases/ and cases.json
+//! cargo test --test json_cases             # or JSON_CASES=/path/to/json-cases cargo test ...
+//! ```
+// floats are compared exactly on purpose, see `numbers_equal`
+#![allow(clippy::float_cmp, clippy::print_stdout)]
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use jiter::JsonValue;
+use serde::Deserialize;
+use serde_json::Value as SerdeValue;
+
+/// One entry of `cases.json`. The index also records the error serde_json gave when it was
+/// written; that is ignored here, this test runs its own copy of serde_json instead.
+#[derive(Deserialize)]
+struct Case {
+    /// absolute path, valid only in the checkout that generated the index
+    path: String,
+    /// the top level directory under `cases/`
+    category: String,
+}
+
+/// How jiter and serde_json disagreed about one document.
+#[derive(Debug)]
+enum Mismatch {
+    /// jiter parsed the document, serde_json rejected it
+    JiterOnly { serde_error: String },
+    /// serde_json parsed the document, jiter rejected it
+    SerdeOnly { jiter_error: String },
+    /// both parsed it, but into different values
+    Value { detail: String },
+    /// both rejected it, but with different errors
+    Error { jiter_error: String, serde_error: String },
+}
+
+impl fmt::Display for Mismatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::JiterOnly { serde_error } => {
+                write!(f, "jiter parsed it, serde_json returned an error: {serde_error:?}")
+            }
+            Self::SerdeOnly { jiter_error } => {
+                write!(f, "serde_json parsed it, jiter returned an error: {jiter_error:?}")
+            }
+            Self::Value { detail } => write!(f, "both parsed it, {detail}"),
+            Self::Error {
+                jiter_error,
+                serde_error,
+            } => {
+                write!(
+                    f,
+                    "both rejected it, jiter returned an error: {jiter_error:?}, serde_json returned an error: {serde_error:?}"
+                )
+            }
+        }
+    }
+}
+
+/// The ways jiter is known to differ from serde_json, and why; anything else is a test failure.
+fn known_difference(mismatch: &Mismatch) -> Option<&'static str> {
+    match mismatch {
+        // jiter refuses integers and floats with more than 4300 digits, matching CPython's default
+        // `sys.set_int_max_str_digits()`; serde_json (built with `arbitrary_precision` here) keeps
+        // the raw token, so it has no such limit
+        Mismatch::SerdeOnly { jiter_error } if starts_with_msg(jiter_error, "number out of range") => {
+            Some("jiter caps numbers at 4300 digits, serde_json does not")
+        }
+        // jiter's recursion limit is 200, serde_json's default is 128, so documents nested between
+        // the two are accepted by jiter alone, and documents that are also malformed hit one limit
+        // or the other first
+        Mismatch::JiterOnly { serde_error } if starts_with_msg(serde_error, "recursion limit exceeded") => {
+            Some("jiter's recursion limit is 200, serde_json's is 128")
+        }
+        Mismatch::Error {
+            jiter_error,
+            serde_error,
+        } if starts_with_msg(jiter_error, "recursion limit exceeded")
+            || starts_with_msg(serde_error, "recursion limit exceeded") =>
+        {
+            Some("jiter's recursion limit is 200, serde_json's is 128")
+        }
+        // the two agree that the document is malformed and on why, but not on where: serde_json
+        // reports the start of the string for an invalid code point (serde-rs/json#1083), and the
+        // two count the start of an invalid escape differently (pydantic/jiter#130)
+        Mismatch::Error {
+            jiter_error,
+            serde_error,
+        } if without_position(jiter_error) == without_position(serde_error)
+            && matches!(
+                without_position(jiter_error),
+                "invalid unicode code point" | "invalid escape"
+            ) =>
+        {
+            Some("same error, different position")
+        }
+        _ => None,
+    }
+}
+
+/// Both parsers suffix their messages with ` at line N column M`; this is the message alone.
+fn without_position(error: &str) -> &str {
+    match error.find(" at line ") {
+        Some(index) => &error[..index],
+        None => error,
+    }
+}
+
+fn starts_with_msg(error: &str, msg: &str) -> bool {
+    without_position(error) == msg
+}
+
+/// The `json-cases` checkout, or `None` if it hasn't been cloned and built.
+fn corpus_root() -> Option<PathBuf> {
+    let root = match std::env::var_os("JSON_CASES") {
+        Some(dir) => PathBuf::from(dir),
+        None => Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../json-cases"),
+    };
+    root.join("cases.json").is_file().then_some(root)
+}
+
+/// `cases.json` holds absolute paths, valid only in the checkout that generated it, so re-root
+/// them; the result doubles as the name to report a case by.
+fn relative(root: &Path, path: &str) -> String {
+    if let Ok(rel) = Path::new(path).strip_prefix(root) {
+        return rel.to_string_lossy().into_owned();
+    }
+    match path.find("/cases/") {
+        Some(index) => path[index + 1..].to_string(),
+        None => path.to_string(),
+    }
+}
+
+fn load_cases(root: &Path) -> Vec<(String, Vec<u8>, String)> {
+    let index = std::fs::read(root.join("cases.json")).unwrap();
+    let cases: Vec<Case> = serde_json::from_slice(&index).unwrap();
+    assert!(!cases.is_empty(), "cases.json is empty, run `make build` in the corpus");
+    cases
+        .into_iter()
+        .map(|case| {
+            let rel = relative(root, &case.path);
+            let json_data =
+                std::fs::read(root.join(&rel)).unwrap_or_else(|e| panic!("{rel}: {e}, run `make build` in the corpus"));
+            (rel, json_data, case.category)
+        })
+        .collect()
+}
+
+/// Parse `json_data` with both parsers, returning how they disagreed, if they did.
+fn compare(json_data: &[u8], allow_inf_nan: bool) -> Option<Mismatch> {
+    match (
+        JsonValue::parse(json_data, allow_inf_nan),
+        serde_json::from_slice::<SerdeValue>(json_data),
+    ) {
+        (Ok(jiter_value), Ok(serde_value)) => {
+            let mut path = String::new();
+            let equal = values_equal(&jiter_value, &serde_value, &mut path);
+            (!equal).then_some(Mismatch::Value { detail: path })
+        }
+        (Ok(_), Err(serde_error)) => Some(Mismatch::JiterOnly {
+            serde_error: serde_error.to_string(),
+        }),
+        (Err(jiter_error), Ok(_)) => Some(Mismatch::SerdeOnly {
+            jiter_error: jiter_error.description(json_data),
+        }),
+        (Err(jiter_error), Err(serde_error)) => {
+            let jiter_error = jiter_error.description(json_data);
+            let serde_error = serde_error.to_string();
+            (jiter_error != serde_error).then_some(Mismatch::Error {
+                jiter_error,
+                serde_error,
+            })
+        }
+    }
+}
+
+/// Compare a jiter value with a serde_json one, describing where they first differ in `detail`.
+fn values_equal(jiter_value: &JsonValue, serde_value: &SerdeValue, detail: &mut String) -> bool {
+    match (jiter_value, serde_value) {
+        (JsonValue::Null, SerdeValue::Null) => true,
+        (JsonValue::Bool(b1), SerdeValue::Bool(b2)) => b1 == b2,
+        (JsonValue::Str(s1), SerdeValue::String(s2)) => s1 == s2,
+        (JsonValue::Int(_) | JsonValue::Float(_), SerdeValue::Number(n)) => {
+            numbers_equal(jiter_value, &n.to_string(), detail)
+        }
+        #[cfg(feature = "num-bigint")]
+        (JsonValue::BigInt(_), SerdeValue::Number(n)) => numbers_equal(jiter_value, &n.to_string(), detail),
+        (JsonValue::Array(a1), SerdeValue::Array(a2)) => {
+            if a1.len() != a2.len() {
+                let _ = write!(detail, "array has {} elements, serde_json got {}", a1.len(), a2.len());
+                return false;
+            }
+            for (index, (v1, v2)) in a1.iter().zip(a2.iter()).enumerate() {
+                if !values_equal(v1, v2, detail) {
+                    detail.insert_str(0, &format!("[{index}]"));
+                    return false;
+                }
+            }
+            true
+        }
+        (JsonValue::Object(o1), SerdeValue::Object(o2)) => {
+            let o1 = deduplicate(o1);
+            if o1.len() != o2.len() {
+                let _ = write!(detail, "object has {} keys, serde_json got {}", o1.len(), o2.len());
+                return false;
+            }
+            for ((k1, v1), (k2, v2)) in o1.iter().zip(o2.iter()) {
+                if k1 != k2 {
+                    let _ = write!(detail, "key {k1:?}, serde_json got {k2:?}");
+                    return false;
+                }
+                if !values_equal(v1, v2, detail) {
+                    detail.insert_str(0, &format!("[{k1:?}]"));
+                    return false;
+                }
+            }
+            true
+        }
+        _ => {
+            let _ = write!(detail, "{jiter_value:?}, serde_json got {serde_value:?}");
+            false
+        }
+    }
+}
+
+/// The object's members with duplicate keys collapsed the way serde_json's map collapses them —
+/// the first position a key appeared at, holding the last value given for it. jiter doesn't
+/// deduplicate while parsing, it leaves that to the caller.
+fn deduplicate<'a, 'j>(object: &'a [(Cow<'j, str>, JsonValue<'j>)]) -> Vec<(&'a str, &'a JsonValue<'j>)> {
+    let mut positions: HashMap<&str, usize> = HashMap::with_capacity(object.len());
+    let mut members: Vec<(&str, &JsonValue)> = Vec::with_capacity(object.len());
+    for (key, value) in object {
+        if let Some(&index) = positions.get(key.as_ref()) {
+            members[index].1 = value;
+        } else {
+            positions.insert(key.as_ref(), members.len());
+            members.push((key.as_ref(), value));
+        }
+    }
+    members
+}
+
+/// serde_json is built with `arbitrary_precision` in this crate's dev-dependencies, so its numbers
+/// are the raw token; compare jiter's decoded number with that token rather than with a second
+/// lossy decode of it.
+fn numbers_equal(jiter_value: &JsonValue, serde_number: &str, detail: &mut String) -> bool {
+    let equal = match jiter_value {
+        JsonValue::Int(i) => serde_number.parse::<i64>().is_ok_and(|s| s == *i),
+        #[cfg(feature = "num-bigint")]
+        JsonValue::BigInt(b) => serde_number.parse::<num_bigint::BigInt>().is_ok_and(|s| &s == b),
+        // both decode with correct rounding, so this is exact rather than approximate
+        JsonValue::Float(f) => serde_number.parse::<f64>().is_ok_and(|s| s == *f),
+        _ => false,
+    };
+    if !equal {
+        let _ = write!(detail, "{jiter_value:?}, serde_json got the token {serde_number}");
+    }
+    equal
+}
+
+/// Every case in the corpus, parsed by jiter and by serde_json, must give the same answer.
+#[test]
+fn compare_to_serde_json() {
+    let Some(root) = corpus_root() else {
+        println!("json-cases corpus not found, skipping (see the module docs)");
+        return;
+    };
+
+    let mut unexpected: Vec<String> = Vec::new();
+    let mut known: HashMap<&'static str, usize> = HashMap::new();
+    let cases = load_cases(&root);
+    for (rel, json_data, _) in &cases {
+        // `allow_inf_nan` is off so that jiter is asked for the same language serde_json parses;
+        // `inf_nan_extension` below covers what turning it on adds
+        if let Some(mismatch) = compare(json_data, false) {
+            match known_difference(&mismatch) {
+                Some(reason) => *known.entry(reason).or_default() += 1,
+                None => unexpected.push(format!("{rel}: {mismatch}")),
+            }
+        }
+    }
+
+    println!("{} cases", cases.len());
+    let mut known: Vec<_> = known.into_iter().collect();
+    known.sort_unstable();
+    for (reason, count) in known {
+        println!("  {count} known differences: {reason}");
+    }
+    assert!(
+        unexpected.is_empty(),
+        "{} of {} cases parsed differently by jiter and serde_json:\n{}",
+        unexpected.len(),
+        cases.len(),
+        unexpected.join("\n")
+    );
+}
+
+/// With `allow_inf_nan` jiter also accepts the `NaN`/`Infinity` documents CPython's `json` module
+/// writes and reads, which are not JSON — the one place jiter deliberately parses more than
+/// serde_json does. It must add nothing else: everything serde_json accepts must still parse to
+/// the same value.
+#[test]
+fn inf_nan_extension() {
+    let Some(root) = corpus_root() else {
+        println!("json-cases corpus not found, skipping (see the module docs)");
+        return;
+    };
+
+    let mut extra: Vec<String> = Vec::new();
+    let mut unexpected: Vec<String> = Vec::new();
+    let cases = load_cases(&root);
+    let inf_nan = cases.iter().filter(|(_, _, category)| category == "python-inf-nan");
+    for (rel, json_data, _) in inf_nan {
+        match compare(json_data, true) {
+            Some(Mismatch::JiterOnly { .. }) => {
+                // the only documents jiter may accept and serde_json reject are the ones this
+                // directory exists for
+                let text = String::from_utf8_lossy(json_data);
+                assert!(
+                    text.contains("NaN") || text.contains("Infinity"),
+                    "{rel}: accepted with allow_inf_nan but holds no NaN/Infinity"
+                );
+                extra.push(rel.clone());
+            }
+            // both rejected it: jiter reads further into a malformed `NaN`/`Infinity` token
+            // before giving up than serde_json does, so only the verdict has to agree here
+            Some(Mismatch::Error { .. }) | None => (),
+            // jiter must not reject, or decode differently, anything serde_json accepts, unless
+            // it is one of the differences the corpus-wide test already allows
+            Some(mismatch) if known_difference(&mismatch).is_none() => unexpected.push(format!("{rel}: {mismatch}")),
+            Some(_) => (),
+        }
+    }
+
+    assert!(unexpected.is_empty(), "{}", unexpected.join("\n"));
+    assert!(
+        !extra.is_empty(),
+        "no NaN/Infinity documents were accepted, is the corpus complete?"
+    );
+    println!("{} NaN/Infinity documents accepted with allow_inf_nan", extra.len());
+}

--- a/crates/jiter/tests/json_cases.rs
+++ b/crates/jiter/tests/json_cases.rs
@@ -3,6 +3,11 @@
 //! and, when it is, on the value it decodes to. The handful of places they legitimately differ are
 //! listed in [`known_difference`]; any other divergence fails the test.
 //!
+//! The corpus also groups documents that are one another's re-spellings — the same document
+//! indented, or with its strings escaped differently — under the `similar` key of `cases.json`;
+//! [`similar_cases_agree`] holds jiter to what that promises, that every member of a group decodes
+//! to the same value, or that they are all rejected.
+//!
 //! `json-cases` is a separate checkout whose `cases/` directory is a build artifact, so these tests
 //! skip themselves when the corpus is not there. `../json-cases` next to this repository is used by
 //! default, `JSON_CASES` overrides it:
@@ -33,6 +38,20 @@ struct Case {
     path: String,
     /// the top level directory under `cases/`
     category: String,
+    /// the other files holding this same document in a different spelling, recorded on one member
+    /// of each group so that following it from every entry visits each group once
+    #[serde(default)]
+    similar: Vec<String>,
+}
+
+/// A case with its content read, and its paths re-rooted at this checkout.
+struct Loaded {
+    /// path relative to the corpus root, doubling as the name to report the case by
+    name: String,
+    json_data: Vec<u8>,
+    category: String,
+    /// the `name`s of the other members of this case's group, see [`Case::similar`]
+    similar: Vec<String>,
 }
 
 /// How jiter and serde_json disagreed about one document.
@@ -145,17 +164,23 @@ fn relative(root: &Path, path: &str) -> String {
     }
 }
 
-fn load_cases(root: &Path) -> Vec<(String, Vec<u8>, String)> {
+fn load_cases(root: &Path) -> Vec<Loaded> {
     let index = std::fs::read(root.join("cases.json")).unwrap();
     let cases: Vec<Case> = serde_json::from_slice(&index).unwrap();
     assert!(!cases.is_empty(), "cases.json is empty, run `make build` in the corpus");
     cases
         .into_iter()
         .map(|case| {
-            let rel = relative(root, &case.path);
-            let json_data =
-                std::fs::read(root.join(&rel)).unwrap_or_else(|e| panic!("{rel}: {e}, run `make build` in the corpus"));
-            (rel, json_data, case.category)
+            let name = relative(root, &case.path);
+            let json_data = std::fs::read(root.join(&name))
+                .unwrap_or_else(|e| panic!("{name}: {e}, run `make build` in the corpus"));
+            let similar = case.similar.iter().map(|path| relative(root, path)).collect();
+            Loaded {
+                name,
+                json_data,
+                category: case.category,
+                similar,
+            }
         })
         .collect()
 }
@@ -283,13 +308,13 @@ fn compare_to_serde_json() {
     let mut unexpected: Vec<String> = Vec::new();
     let mut known: HashMap<&'static str, usize> = HashMap::new();
     let cases = load_cases(&root);
-    for (rel, json_data, _) in &cases {
+    for case in &cases {
         // `allow_inf_nan` is off so that jiter is asked for the same language serde_json parses;
         // `inf_nan_extension` below covers what turning it on adds
-        if let Some(mismatch) = compare(json_data, false) {
+        if let Some(mismatch) = compare(&case.json_data, false) {
             match known_difference(&mismatch) {
                 Some(reason) => *known.entry(reason).or_default() += 1,
-                None => unexpected.push(format!("{rel}: {mismatch}")),
+                None => unexpected.push(format!("{}: {mismatch}", case.name)),
             }
         }
     }
@@ -323,25 +348,28 @@ fn inf_nan_extension() {
     let mut extra: Vec<String> = Vec::new();
     let mut unexpected: Vec<String> = Vec::new();
     let cases = load_cases(&root);
-    let inf_nan = cases.iter().filter(|(_, _, category)| category == "python-inf-nan");
-    for (rel, json_data, _) in inf_nan {
-        match compare(json_data, true) {
+    let inf_nan = cases.iter().filter(|case| case.category == "python-inf-nan");
+    for case in inf_nan {
+        match compare(&case.json_data, true) {
             Some(Mismatch::JiterOnly { .. }) => {
                 // the only documents jiter may accept and serde_json reject are the ones this
                 // directory exists for
-                let text = String::from_utf8_lossy(json_data);
+                let text = String::from_utf8_lossy(&case.json_data);
                 assert!(
                     text.contains("NaN") || text.contains("Infinity"),
-                    "{rel}: accepted with allow_inf_nan but holds no NaN/Infinity"
+                    "{}: accepted with allow_inf_nan but holds no NaN/Infinity",
+                    case.name
                 );
-                extra.push(rel.clone());
+                extra.push(case.name.clone());
             }
             // both rejected it: jiter reads further into a malformed `NaN`/`Infinity` token
             // before giving up than serde_json does, so only the verdict has to agree here
             Some(Mismatch::Error { .. }) | None => (),
             // jiter must not reject, or decode differently, anything serde_json accepts, unless
             // it is one of the differences the corpus-wide test already allows
-            Some(mismatch) if known_difference(&mismatch).is_none() => unexpected.push(format!("{rel}: {mismatch}")),
+            Some(mismatch) if known_difference(&mismatch).is_none() => {
+                unexpected.push(format!("{}: {mismatch}", case.name));
+            }
             Some(_) => (),
         }
     }
@@ -352,4 +380,123 @@ fn inf_nan_extension() {
         "no NaN/Infinity documents were accepted, is the corpus complete?"
     );
     println!("{} NaN/Infinity documents accepted with allow_inf_nan", extra.len());
+}
+
+/// Compare two values jiter decoded, describing where they first differ in `detail`. Members of a
+/// group hold the same numbers written the same way and the same keys in the same order, so this
+/// is exact, structural equality; `NaN`, which is not equal to itself, is the one special case.
+fn jiter_values_equal(v1: &JsonValue, v2: &JsonValue, detail: &mut String) -> bool {
+    match (v1, v2) {
+        (JsonValue::Float(f1), JsonValue::Float(f2)) if f1.is_nan() && f2.is_nan() => true,
+        (JsonValue::Array(a1), JsonValue::Array(a2)) => {
+            if a1.len() != a2.len() {
+                let _ = write!(detail, "array has {} elements, the other has {}", a1.len(), a2.len());
+                return false;
+            }
+            for (index, (e1, e2)) in a1.iter().zip(a2.iter()).enumerate() {
+                if !jiter_values_equal(e1, e2, detail) {
+                    detail.insert_str(0, &format!("[{index}]"));
+                    return false;
+                }
+            }
+            true
+        }
+        // jiter doesn't deduplicate keys, and neither does the corpus: a group repeats the same
+        // key the same number of times, so the members are compared as written
+        (JsonValue::Object(o1), JsonValue::Object(o2)) => {
+            if o1.len() != o2.len() {
+                let _ = write!(detail, "object has {} keys, the other has {}", o1.len(), o2.len());
+                return false;
+            }
+            for ((k1, e1), (k2, e2)) in o1.iter().zip(o2.iter()) {
+                if k1 != k2 {
+                    let _ = write!(detail, "key {k1:?}, the other has {k2:?}");
+                    return false;
+                }
+                if !jiter_values_equal(e1, e2, detail) {
+                    detail.insert_str(0, &format!("[{k1:?}]"));
+                    return false;
+                }
+            }
+            true
+        }
+        _ => {
+            if v1 == v2 {
+                return true;
+            }
+            let _ = write!(detail, "{v1:?}, the other has {v2:?}");
+            false
+        }
+    }
+}
+
+/// The members of a `similar` group are one document written several ways — re-indented, or with
+/// its strings escaped differently — so jiter must decode them all to the same value, or, where
+/// the document is malformed, reject them all. Only *where* the error is reported may vary within
+/// a rejected group, the spellings put the same mistake in different places.
+#[test]
+fn similar_cases_agree() {
+    let Some(root) = corpus_root() else {
+        println!("json-cases corpus not found, skipping (see the module docs)");
+        return;
+    };
+
+    let cases = load_cases(&root);
+    let by_name: HashMap<&str, &Loaded> = cases.iter().map(|case| (case.name.as_str(), case)).collect();
+    let mut failures: Vec<String> = Vec::new();
+    let mut groups = 0;
+    let mut documents = 0;
+
+    for case in cases.iter().filter(|case| !case.similar.is_empty()) {
+        groups += 1;
+        documents += case.similar.len() + 1;
+        // what a group promises is a property of the document, not of how jiter is configured, so
+        // it has to hold either way; `allow_inf_nan` is also what makes the `python-inf-nan`
+        // groups compare values at all rather than agree on rejecting them
+        for allow_inf_nan in [false, true] {
+            let first = JsonValue::parse(&case.json_data, allow_inf_nan);
+            for name in &case.similar {
+                let other = by_name
+                    .get(name.as_str())
+                    .unwrap_or_else(|| panic!("{name}: listed as similar but missing from cases.json"));
+                match (&first, JsonValue::parse(&other.json_data, allow_inf_nan)) {
+                    (Ok(value), Ok(other_value)) => {
+                        let mut detail = String::new();
+                        if !jiter_values_equal(value, &other_value, &mut detail) {
+                            failures.push(format!(
+                                "{} and {} (allow_inf_nan={allow_inf_nan}) decoded differently: {detail}",
+                                case.name, other.name
+                            ));
+                        }
+                    }
+                    // both rejected, which is all a group of malformed documents promises
+                    (Err(_), Err(_)) => (),
+                    (Ok(_), Err(error)) => failures.push(format!(
+                        "{} parsed (allow_inf_nan={allow_inf_nan}), {} was rejected: {}",
+                        case.name,
+                        other.name,
+                        error.description(&other.json_data)
+                    )),
+                    (Err(error), Ok(_)) => failures.push(format!(
+                        "{} was rejected (allow_inf_nan={allow_inf_nan}): {}, {} parsed",
+                        case.name,
+                        error.description(&case.json_data),
+                        other.name
+                    )),
+                }
+            }
+        }
+    }
+
+    assert!(
+        groups > 0,
+        "cases.json holds no `similar` groups, is the corpus complete?"
+    );
+    assert!(
+        failures.is_empty(),
+        "{} comparisons across {groups} similar groups disagreed:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+    println!("{groups} similar groups, {documents} documents");
 }

--- a/crates/jiter/tests/json_cases.rs
+++ b/crates/jiter/tests/json_cases.rs
@@ -1,4 +1,4 @@
-//! Compare `jiter` with `serde_json` over the [`json-cases`](https://github.com/pydantic/json-cases)
+//! Compare `jiter` with `serde_json` over the [`json-cases`](https://github.com/samuelcolvin/json-cases)
 //! corpus: every document is parsed by both, and the two must agree on whether it is valid JSON
 //! and, when it is, on the value it decodes to. The handful of places they legitimately differ are
 //! listed in [`known_difference`]; any other divergence fails the test.
@@ -8,12 +8,11 @@
 //! [`similar_cases_agree`] holds jiter to what that promises, that every member of a group decodes
 //! to the same value, or that they are all rejected.
 //!
-//! `json-cases` is a separate checkout whose `cases/` directory is a build artifact, so these tests
-//! skip themselves when the corpus is not there. `../json-cases` next to this repository is used by
-//! default, `JSON_CASES` overrides it:
+//! The corpus is a separate checkout, loaded by [`corpus`]; these tests skip themselves when it is
+//! not there:
 //!
 //! ```bash
-//! git clone https://github.com/pydantic/json-cases ../json-cases
+//! git clone https://github.com/samuelcolvin/json-cases ../json-cases
 //! make -C ../json-cases build              # writes cases/ and cases.json
 //! cargo test --test json_cases             # or JSON_CASES=/path/to/json-cases cargo test ...
 //! ```
@@ -24,35 +23,13 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Write as _;
-use std::path::{Path, PathBuf};
 
 use jiter::JsonValue;
-use serde::Deserialize;
 use serde_json::Value as SerdeValue;
 
-/// One entry of `cases.json`. The index also records the error serde_json gave when it was
-/// written; that is ignored here, this test runs its own copy of serde_json instead.
-#[derive(Deserialize)]
-struct Case {
-    /// absolute path, valid only in the checkout that generated the index
-    path: String,
-    /// the top level directory under `cases/`
-    category: String,
-    /// the other files holding this same document in a different spelling, recorded on one member
-    /// of each group so that following it from every entry visits each group once
-    #[serde(default)]
-    similar: Vec<String>,
-}
+mod corpus;
 
-/// A case with its content read, and its paths re-rooted at this checkout.
-struct Loaded {
-    /// path relative to the corpus root, doubling as the name to report the case by
-    name: String,
-    json_data: Vec<u8>,
-    category: String,
-    /// the `name`s of the other members of this case's group, see [`Case::similar`]
-    similar: Vec<String>,
-}
+use corpus::{Loaded, corpus_root, load_cases};
 
 /// How jiter and serde_json disagreed about one document.
 #[derive(Debug)]
@@ -141,48 +118,6 @@ fn without_position(error: &str) -> &str {
 
 fn starts_with_msg(error: &str, msg: &str) -> bool {
     without_position(error) == msg
-}
-
-/// The `json-cases` checkout, or `None` if it hasn't been cloned and built.
-fn corpus_root() -> Option<PathBuf> {
-    let root = match std::env::var_os("JSON_CASES") {
-        Some(dir) => PathBuf::from(dir),
-        None => Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../json-cases"),
-    };
-    root.join("cases.json").is_file().then_some(root)
-}
-
-/// `cases.json` holds absolute paths, valid only in the checkout that generated it, so re-root
-/// them; the result doubles as the name to report a case by.
-fn relative(root: &Path, path: &str) -> String {
-    if let Ok(rel) = Path::new(path).strip_prefix(root) {
-        return rel.to_string_lossy().into_owned();
-    }
-    match path.find("/cases/") {
-        Some(index) => path[index + 1..].to_string(),
-        None => path.to_string(),
-    }
-}
-
-fn load_cases(root: &Path) -> Vec<Loaded> {
-    let index = std::fs::read(root.join("cases.json")).unwrap();
-    let cases: Vec<Case> = serde_json::from_slice(&index).unwrap();
-    assert!(!cases.is_empty(), "cases.json is empty, run `make build` in the corpus");
-    cases
-        .into_iter()
-        .map(|case| {
-            let name = relative(root, &case.path);
-            let json_data = std::fs::read(root.join(&name))
-                .unwrap_or_else(|e| panic!("{name}: {e}, run `make build` in the corpus"));
-            let similar = case.similar.iter().map(|path| relative(root, path)).collect();
-            Loaded {
-                name,
-                json_data,
-                category: case.category,
-                similar,
-            }
-        })
-        .collect()
 }
 
 /// Parse `json_data` with both parsers, returning how they disagreed, if they did.
@@ -301,10 +236,8 @@ fn numbers_equal(jiter_value: &JsonValue, serde_number: &str, detail: &mut Strin
 #[test]
 fn compare_to_serde_json() {
     let Some(root) = corpus_root() else {
-        println!("json-cases corpus not found, skipping (see the module docs)");
         return;
     };
-
     let mut unexpected: Vec<String> = Vec::new();
     let mut known: HashMap<&'static str, usize> = HashMap::new();
     let cases = load_cases(&root);
@@ -341,10 +274,8 @@ fn compare_to_serde_json() {
 #[test]
 fn inf_nan_extension() {
     let Some(root) = corpus_root() else {
-        println!("json-cases corpus not found, skipping (see the module docs)");
         return;
     };
-
     let mut extra: Vec<String> = Vec::new();
     let mut unexpected: Vec<String> = Vec::new();
     let cases = load_cases(&root);
@@ -437,10 +368,8 @@ fn jiter_values_equal(v1: &JsonValue, v2: &JsonValue, detail: &mut String) -> bo
 #[test]
 fn similar_cases_agree() {
     let Some(root) = corpus_root() else {
-        println!("json-cases corpus not found, skipping (see the module docs)");
         return;
     };
-
     let cases = load_cases(&root);
     let by_name: HashMap<&str, &Loaded> = cases.iter().map(|case| (case.name.as_str(), case)).collect();
     let mut failures: Vec<String> = Vec::new();


### PR DESCRIPTION
Adds `crates/jiter/tests/json_cases.rs`, which parses every document in the json-cases corpus with both `JsonValue::parse` and `serde_json`, and requires the two to agree on whether it is valid JSON, on the value it decodes to, and on the error message when they reject it.

The places they legitimately differ are listed in `known_difference()` with a reason, and nothing else is allowed: jiter's 4300 digit cap on numbers, its recursion limit of 200 against serde_json's 128, and the two errors where the message matches but the position doesn't (serde-rs/json#1083, #130).

A second test covers `allow_inf_nan`, the one place jiter deliberately parses more than serde_json does: the NaN/Infinity extension must be purely additive, so everything serde_json accepts still decodes to the same value.

The corpus is a separate checkout whose `cases/` is a build artifact, so both tests skip themselves when it isn't there; `../json-cases` is used by default and `JSON_CASES` overrides it.


Claude-Session: https://claude.ai/code/session_01KLR7FhfVNh2Qmd8WS7NwHD