### PR TITLE
Size containers from their siblings, and from the bytes left

### DIFF
--- a/crates/jiter/examples/alloc_count.rs
+++ b/crates/jiter/examples/alloc_count.rs
@@ -1,0 +1,97 @@
+//! Count the allocator traffic of `JsonValue::parse` over the benchmark documents. Unlike a
+//! timing run this is deterministic, so it can be trusted on a busy machine.
+#![allow(clippy::print_stdout)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static REALLOCS: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Relaxed);
+        BYTES.fetch_add(layout.size(), Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        REALLOCS.fetch_add(1, Relaxed);
+        BYTES.fetch_add(new_size.saturating_sub(layout.size()), Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+fn main() {
+    let mut names: Vec<String> = std::fs::read_dir("crates/jiter/benches")
+        .or_else(|_| std::fs::read_dir("benches"))
+        .expect("run from the repository root")
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            (path.extension()? == "json").then(|| path.to_string_lossy().into_owned())
+        })
+        .collect();
+    names.sort();
+
+    println!("{:<28} {:>10} {:>10} {:>12}", "document", "allocs", "reallocs", "bytes");
+    let (mut total_allocs, mut total_reallocs, mut total_bytes) = (0, 0, 0);
+    for name in &names {
+        let json_data = std::fs::read(name).unwrap();
+        let short = name.rsplit('/').next().unwrap().trim_end_matches(".json").to_string();
+        ALLOCS.store(0, Relaxed);
+        REALLOCS.store(0, Relaxed);
+        BYTES.store(0, Relaxed);
+        let value = jiter::JsonValue::parse(&json_data, false).unwrap();
+        let (allocs, reallocs, bytes) = (ALLOCS.load(Relaxed), REALLOCS.load(Relaxed), BYTES.load(Relaxed));
+        drop(value);
+        println!("{short:<28} {allocs:>10} {reallocs:>10} {bytes:>12}");
+        total_allocs += allocs;
+        total_reallocs += reallocs;
+        total_bytes += bytes;
+    }
+    println!(
+        "{:<28} {total_allocs:>10} {total_reallocs:>10} {total_bytes:>12}",
+        "TOTAL"
+    );
+
+    // and the whole json-cases corpus as one number, if it is available
+    let Some(root) = std::env::var_os("JSON_CASES") else {
+        return;
+    };
+    let root = std::path::PathBuf::from(root);
+    let index = std::fs::read(root.join("cases.json")).unwrap();
+    let cases: serde_json::Value = serde_json::from_slice(&index).unwrap();
+    let documents: Vec<Vec<u8>> = cases
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|case| {
+            let path = case["path"].as_str().unwrap();
+            let rel = &path[path.find("/cases/").unwrap() + 1..];
+            std::fs::read(root.join(rel)).unwrap()
+        })
+        .collect();
+    ALLOCS.store(0, Relaxed);
+    REALLOCS.store(0, Relaxed);
+    BYTES.store(0, Relaxed);
+    for json_data in &documents {
+        drop(jiter::JsonValue::parse(json_data, false));
+    }
+    println!(
+        "{:<28} {:>10} {:>10} {:>12}",
+        format!("corpus ({} docs)", documents.len()),
+        ALLOCS.load(Relaxed),
+        REALLOCS.load(Relaxed),
+        BYTES.load(Relaxed)
+    );
+}

--- a/crates/jiter/src/parse.rs
+++ b/crates/jiter/src/parse.rs
@@ -69,6 +69,11 @@ impl<'j> Parser<'j> {
         Self { data, index: 0 }
     }
 
+    /// Bytes of the document not consumed yet, which bounds what is left of any container in it.
+    pub fn remaining(&self) -> usize {
+        self.data.len().saturating_sub(self.index)
+    }
+
     #[allow(dead_code)]
     pub fn slice(&self, range: Range<usize>) -> Option<&[u8]> {
         self.data.get(range)

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -252,7 +252,7 @@ fn take_value<'j, 's>(
             };
             take_value_recursive(
                 peek_first,
-                RecursedValue::new_array(),
+                RecursedValue::new_array(parser.index, DEFAULT_CAPACITY),
                 parser,
                 tape,
                 recursion_limit,
@@ -272,7 +272,7 @@ fn take_value<'j, 's>(
             match parser.peek() {
                 Ok(peek) => take_value_recursive(
                     peek,
-                    RecursedValue::new_object(first_key),
+                    RecursedValue::new_object(first_key, parser.index, DEFAULT_CAPACITY),
                     parser,
                     tape,
                     recursion_limit,
@@ -303,25 +303,65 @@ fn take_value<'j, 's>(
     }
 }
 
+/// What the first array or object of a document starts with, and the floor for every guess after.
+const DEFAULT_CAPACITY: usize = 8;
+
 enum RecursedValue<'s> {
-    Array(Vec<JsonValue<'s>>),
+    Array {
+        array: Vec<JsonValue<'s>>,
+        /// index the first element started at, see [`reserve_for_rest`]
+        start: usize,
+    },
     Object {
         partial: Vec<(Cow<'s, str>, JsonValue<'s>)>,
         next_key: Cow<'s, str>,
+        /// index the first member started at, see [`reserve_for_rest`]
+        start: usize,
     },
 }
 
 impl<'s> RecursedValue<'s> {
-    fn new_array() -> Self {
-        RecursedValue::Array(Vec::with_capacity(8))
-    }
-
-    fn new_object(next_key: Cow<'s, str>) -> Self {
-        RecursedValue::Object {
-            partial: Vec::with_capacity(8),
-            next_key,
+    fn new_array(start: usize, capacity: usize) -> Self {
+        RecursedValue::Array {
+            array: Vec::with_capacity(capacity),
+            start,
         }
     }
+
+    fn new_object(next_key: Cow<'s, str>, start: usize, capacity: usize) -> Self {
+        RecursedValue::Object {
+            partial: Vec::with_capacity(capacity),
+            next_key,
+            start,
+        }
+    }
+}
+
+/// What a container of `len` elements suggests for the next one of its kind: never below the
+/// default, and capped so that one big container doesn't make every later one expensive.
+#[inline]
+fn capacity_guess(len: usize) -> usize {
+    len.clamp(DEFAULT_CAPACITY, 512)
+}
+
+/// Give a full container room for what is probably left of it, instead of letting it double.
+///
+/// Elements of one container tend to be the same size, so the bytes it has taken for the elements
+/// it holds predict how many more the rest of the document can hold. The estimate is wrong for a
+/// container followed by a lot of unrelated document — it sees bytes that aren't its own — so it
+/// is capped at eight times the current length, and never asks for less than the doubling it
+/// replaces.
+#[inline]
+fn reserve_for_rest<T>(items: &mut Vec<T>, start: usize, parser: &Parser<'_>) {
+    let len = items.len();
+    if items.capacity() != DEFAULT_CAPACITY {
+        // the capacity came from a sibling, which knows more than this estimate does; double
+        items.reserve(len);
+        return;
+    }
+    let consumed = parser.index.saturating_sub(start).max(len);
+    let estimate = parser.remaining() / (consumed / len);
+    items.reserve(estimate.clamp(len, len * 8));
 }
 
 #[inline(never)] // this is an iterative algo called only from take_value, no point in inlining
@@ -340,6 +380,10 @@ fn take_value_recursive<'j, 's>(
     let recursion_limit: usize = recursion_limit.into();
 
     let mut recursion_stack: SmallVec<[RecursedValue; 8]> = SmallVec::new();
+    // documents are usually uniform, so the container just finished is the best guess at the size
+    // of the next one of its kind; the first of each gets DEFAULT_CAPACITY
+    let mut last_array_len = DEFAULT_CAPACITY;
+    let mut last_object_len = DEFAULT_CAPACITY;
     let partial_active = allow_partial.is_active();
 
     macro_rules! push_recursion {
@@ -354,7 +398,7 @@ fn take_value_recursive<'j, 's>(
 
     'recursion: loop {
         let mut value = match &mut current_recursion {
-            RecursedValue::Array(array) => {
+            RecursedValue::Array { array, start } => {
                 loop {
                     let result = match peek {
                         Peek::True => parser.consume_true().map(|()| JsonValue::Bool(true)),
@@ -366,7 +410,7 @@ fn take_value_recursive<'j, 's>(
                         Peek::Array => {
                             match parser.array_first() {
                                 Ok(Some(first_peek)) => {
-                                    push_recursion!(first_peek, RecursedValue::new_array());
+                                    push_recursion!(first_peek, RecursedValue::new_array(parser.index, last_array_len));
                                     // immediately jump to process the first value in the array
                                     continue 'recursion;
                                 }
@@ -379,7 +423,14 @@ fn take_value_recursive<'j, 's>(
                             match parser.object_first::<StringDecoder>(tape) {
                                 Ok(Some(first_key)) => match parser.peek() {
                                     Ok(peek) => {
-                                        push_recursion!(peek, RecursedValue::new_object(create_cow(first_key)));
+                                        push_recursion!(
+                                            peek,
+                                            RecursedValue::new_object(
+                                                create_cow(first_key),
+                                                parser.index,
+                                                last_object_len
+                                            )
+                                        );
                                         continue 'recursion;
                                     }
                                     Err(e) if !(partial_active && e.allowed_if_partial()) => return Err(e),
@@ -412,6 +463,9 @@ fn take_value_recursive<'j, 's>(
                             // now try to advance position in the current array
                             match parser.array_step() {
                                 Ok(Some(next_peek)) => {
+                                    if array.len() == array.capacity() {
+                                        reserve_for_rest(array, *start, parser);
+                                    }
                                     array.push(value);
                                     peek = next_peek;
                                     // array continuing
@@ -421,7 +475,7 @@ fn take_value_recursive<'j, 's>(
                                 _ => (),
                             }
 
-                            let RecursedValue::Array(mut array) = current_recursion else {
+                            let RecursedValue::Array { mut array, .. } = current_recursion else {
                                 unreachable!("known to be in array recursion");
                             };
                             array.push(value);
@@ -429,17 +483,22 @@ fn take_value_recursive<'j, 's>(
                         }
                         Err(e) if !(partial_active && e.allowed_if_partial()) => return Err(e),
                         _ => {
-                            let RecursedValue::Array(array) = current_recursion else {
+                            let RecursedValue::Array { array, .. } = current_recursion else {
                                 unreachable!("known to be in array recursion");
                             };
                             array
                         }
                     };
 
+                    last_array_len = capacity_guess(array.len());
                     break JsonValue::Array(Arc::new(array));
                 }
             }
-            RecursedValue::Object { partial, next_key } => {
+            RecursedValue::Object {
+                partial,
+                next_key,
+                start,
+            } => {
                 loop {
                     let result = match peek {
                         Peek::True => parser.consume_true().map(|()| JsonValue::Bool(true)),
@@ -451,7 +510,7 @@ fn take_value_recursive<'j, 's>(
                         Peek::Array => {
                             match parser.array_first() {
                                 Ok(Some(first_peek)) => {
-                                    push_recursion!(first_peek, RecursedValue::new_array());
+                                    push_recursion!(first_peek, RecursedValue::new_array(parser.index, last_array_len));
                                     // immediately jump to process the first value in the array
                                     continue 'recursion;
                                 }
@@ -464,7 +523,14 @@ fn take_value_recursive<'j, 's>(
                             match parser.object_first::<StringDecoder>(tape) {
                                 Ok(Some(first_key)) => match parser.peek() {
                                     Ok(peek) => {
-                                        push_recursion!(peek, RecursedValue::new_object(create_cow(first_key)));
+                                        push_recursion!(
+                                            peek,
+                                            RecursedValue::new_object(
+                                                create_cow(first_key),
+                                                parser.index,
+                                                last_object_len
+                                            )
+                                        );
                                         continue 'recursion;
                                     }
                                     Err(e) if !(partial_active && e.allowed_if_partial()) => return Err(e),
@@ -500,6 +566,9 @@ fn take_value_recursive<'j, 's>(
                                     match parser.peek() {
                                         Ok(next_peek) => {
                                             // object continuing
+                                            if partial.len() == partial.capacity() {
+                                                reserve_for_rest(partial, *start, parser);
+                                            }
                                             partial.push((
                                                 std::mem::replace(next_key, create_cow(yet_another_key)),
                                                 value,
@@ -515,7 +584,10 @@ fn take_value_recursive<'j, 's>(
                                 _ => (),
                             }
 
-                            let RecursedValue::Object { mut partial, next_key } = current_recursion else {
+                            let RecursedValue::Object {
+                                mut partial, next_key, ..
+                            } = current_recursion
+                            else {
                                 unreachable!("known to be in object recursion");
                             };
                             partial.push((next_key, value));
@@ -530,6 +602,7 @@ fn take_value_recursive<'j, 's>(
                         }
                     };
 
+                    last_object_len = capacity_guess(object.len());
                     break JsonValue::Object(Arc::new(object));
                 }
             }
@@ -545,19 +618,30 @@ fn take_value_recursive<'j, 's>(
             }
 
             value = match current_recursion {
-                RecursedValue::Array(mut array) => {
+                RecursedValue::Array { mut array, start } => {
+                    if array.len() == array.capacity() {
+                        reserve_for_rest(&mut array, start, parser);
+                    }
                     array.push(value);
                     match parser.array_step() {
                         Ok(Some(next_peek)) => {
-                            current_recursion = RecursedValue::Array(array);
+                            current_recursion = RecursedValue::Array { array, start };
                             break next_peek;
                         }
                         Err(e) if !(partial_active && e.allowed_if_partial()) => return Err(e),
                         _ => (),
                     }
+                    last_array_len = capacity_guess(array.len());
                     JsonValue::Array(Arc::new(array))
                 }
-                RecursedValue::Object { mut partial, next_key } => {
+                RecursedValue::Object {
+                    mut partial,
+                    next_key,
+                    start,
+                } => {
+                    if partial.len() == partial.capacity() {
+                        reserve_for_rest(&mut partial, start, parser);
+                    }
                     partial.push((next_key, value));
 
                     match parser.object_step::<StringDecoder>(tape) {
@@ -566,6 +650,7 @@ fn take_value_recursive<'j, 's>(
                                 current_recursion = RecursedValue::Object {
                                     partial,
                                     next_key: create_cow(next_key),
+                                    start,
                                 };
                                 break next_peek;
                             }
@@ -576,6 +661,7 @@ fn take_value_recursive<'j, 's>(
                         _ => (),
                     }
 
+                    last_object_len = capacity_guess(partial.len());
                     JsonValue::Object(Arc::new(partial))
                 }
             }


### PR DESCRIPTION
Prototype, **one of a pair** — the other is #269, the shared scratch stack. Both attack the same finding and only one should land; they are open together so CodSpeed can measure them deterministically, which a busy laptop cannot.

## The finding

CodSpeed's flamegraph on #266 put **41.6% of `true_array_jiter_value` in the `realloc` subtree**, reached via `RawVec::grow_one`. A container's `Vec` starts at 8 and doubles, so its size is guessed at repeatedly and paid for in reallocations. Over the json-cases corpus that is 13 537 reallocations against 200 423 allocations.

## This approach: predict the size

Two predictions, each covering what the other cannot:

- **Siblings.** Documents are usually uniform, so a container starts at the capacity of the last container of its kind (`capacity_guess`). This is what fixes an array of many similar objects — `big.json` goes from 4957 reallocations to 1003.
- **Density.** The first container of each kind has no sibling to learn from, so on its first growth it estimates from itself: bytes taken for the elements it holds, against bytes left in the document (`reserve_for_rest`). Capped at 8×, because a container followed by a lot of unrelated document sees bytes that are not its own. This is what fixes a single wide top-level array, which siblings structurally cannot.

Once a container has been sized by a sibling it just doubles — letting both fire compounds their over-allocation (31.7 MB on `big.json` alone).

## Measurements

Allocator traffic over the corpus, 2775 documents, via `crates/jiter/examples/alloc_count.rs` (deterministic, unlike timing):

| | allocations | reallocations | bytes requested |
| --- | --- | --- | --- |
| main | 200 423 | 13 537 | 93.9 MB |
| this branch | 200 423 | 7 464 (−45%) | 99.6 MB (+6%) |
| scratch stack | 164 383 (−18%) | 6 922 (−49%) | 68.6 MB (−27%) |

Local timings, **indicative only** — measured on a loaded machine where `x100`, `sentence` and `unicode`, documents containing no containers at all, moved 2–5%:

| benchmark | this branch | scratch stack |
| --- | --- | --- |
| `true_array` | **−16.7%** | +5.1% |
| `true_object` | **−10.2%** | +6.5% |
| `string_array` | **−11.3%** | +7.0% |
| `big` | +0.6% (n.s.) | **−6.1%** |
| `medium_response` | −0.7% | **−4.1%** |

The split is the interesting part: prediction wins on flat single-container documents, the scratch stack (#269) wins on the nested many-container ones that look like real payloads.

## Notes

- Trades memory for speed: 6% more bytes requested. The scratch stack asks for 27% less.
- All 203 tests pass, including the json-cases corpus and the Python bindings.
- `alloc_count.rs` is measurement scaffolding; it would come out before this landed.