### PR TITLE
Build containers on shared stacks, allocate them exactly once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ env*/
 profile.json
 __pycache__
 /worktrees/
+/crates/fuzz/Cargo.lock

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
 name = "fuzz"
-publish = false
 # Internal-only crate (`publish = false`): keep version decoupled from release crates.
+publish = false
 version = "0.0.0"
 edition = "2021"
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]
 
 [package.metadata]
 cargo-fuzz = true
+
+# not a member of the workspace to avoid upsetting maturin and fuzz profiles
+# empty workspace so fuzzing works from a worktree directory nested inside the main repo
+[workspace]
 
 [dependencies]
 libfuzzer-sys = "0.4.7"

--- a/crates/jiter/examples/alloc_count.rs
+++ b/crates/jiter/examples/alloc_count.rs
@@ -1,0 +1,97 @@
+//! Count the allocator traffic of `JsonValue::parse` over the benchmark documents. Unlike a
+//! timing run this is deterministic, so it can be trusted on a busy machine.
+#![allow(clippy::print_stdout)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static REALLOCS: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Relaxed);
+        BYTES.fetch_add(layout.size(), Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        REALLOCS.fetch_add(1, Relaxed);
+        BYTES.fetch_add(new_size.saturating_sub(layout.size()), Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+fn main() {
+    let mut names: Vec<String> = std::fs::read_dir("crates/jiter/benches")
+        .or_else(|_| std::fs::read_dir("benches"))
+        .expect("run from the repository root")
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            (path.extension()? == "json").then(|| path.to_string_lossy().into_owned())
+        })
+        .collect();
+    names.sort();
+
+    println!("{:<28} {:>10} {:>10} {:>12}", "document", "allocs", "reallocs", "bytes");
+    let (mut total_allocs, mut total_reallocs, mut total_bytes) = (0, 0, 0);
+    for name in &names {
+        let json_data = std::fs::read(name).unwrap();
+        let short = name.rsplit('/').next().unwrap().trim_end_matches(".json").to_string();
+        ALLOCS.store(0, Relaxed);
+        REALLOCS.store(0, Relaxed);
+        BYTES.store(0, Relaxed);
+        let value = jiter::JsonValue::parse(&json_data, false).unwrap();
+        let (allocs, reallocs, bytes) = (ALLOCS.load(Relaxed), REALLOCS.load(Relaxed), BYTES.load(Relaxed));
+        drop(value);
+        println!("{short:<28} {allocs:>10} {reallocs:>10} {bytes:>12}");
+        total_allocs += allocs;
+        total_reallocs += reallocs;
+        total_bytes += bytes;
+    }
+    println!(
+        "{:<28} {total_allocs:>10} {total_reallocs:>10} {total_bytes:>12}",
+        "TOTAL"
+    );
+
+    // and the whole json-cases corpus as one number, if it is available
+    let Some(root) = std::env::var_os("JSON_CASES") else {
+        return;
+    };
+    let root = std::path::PathBuf::from(root);
+    let index = std::fs::read(root.join("cases.json")).unwrap();
+    let cases: serde_json::Value = serde_json::from_slice(&index).unwrap();
+    let documents: Vec<Vec<u8>> = cases
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|case| {
+            let path = case["path"].as_str().unwrap();
+            let rel = &path[path.find("/cases/").unwrap() + 1..];
+            std::fs::read(root.join(rel)).unwrap()
+        })
+        .collect();
+    ALLOCS.store(0, Relaxed);
+    REALLOCS.store(0, Relaxed);
+    BYTES.store(0, Relaxed);
+    for json_data in &documents {
+        drop(jiter::JsonValue::parse(json_data, false));
+    }
+    println!(
+        "{:<28} {:>10} {:>10} {:>12}",
+        format!("corpus ({} docs)", documents.len()),
+        ALLOCS.load(Relaxed),
+        REALLOCS.load(Relaxed),
+        BYTES.load(Relaxed)
+    );
+}

--- a/crates/jiter/examples/alloc_count.rs
+++ b/crates/jiter/examples/alloc_count.rs
@@ -24,7 +24,7 @@ unsafe impl GlobalAlloc for Counting {
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         REALLOCS.fetch_add(1, Relaxed);
-        BYTES.fetch_add(new_size.saturating_sub(layout.size()), Relaxed);
+        BYTES.fetch_add(new_size, Relaxed);
         unsafe { System.realloc(ptr, layout, new_size) }
     }
 }
@@ -76,8 +76,16 @@ fn main() {
         .unwrap()
         .iter()
         .map(|case| {
+            // cases.json holds absolute paths from the checkout that generated it; re-root them
+            // like tests/corpus does
             let path = case["path"].as_str().unwrap();
-            let rel = &path[path.find("/cases/").unwrap() + 1..];
+            let rel = match std::path::Path::new(path).strip_prefix(&root) {
+                Ok(rel) => rel.to_string_lossy().into_owned(),
+                Err(_) => match path.find("/cases/") {
+                    Some(index) => path[index + 1..].to_string(),
+                    None => path.to_string(),
+                },
+            };
             std::fs::read(root.join(rel)).unwrap()
         })
         .collect();

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -351,8 +351,13 @@ fn take_value_recursive<'j, 's>(
     // are always the top of the stack, from its `base` up; closing it copies them out into an
     // allocation of exactly the right size. A `Vec` per container has to guess that size instead,
     // and pays a run of reallocations for guessing low.
-    let mut elements: Vec<JsonValue<'s>> = Vec::new();
-    let mut members: Vec<(Cow<'s, str>, JsonValue<'s>)> = Vec::new();
+    // Only the root container's stack is allocated up front; a document that never opens a
+    // container of the other kind never pays for its stack.
+    let (mut elements, mut members): (Vec<JsonValue<'s>>, Vec<(Cow<'s, str>, JsonValue<'s>)>) = match &current_recursion
+    {
+        RecursedValue::Array { .. } => (Vec::with_capacity(8), Vec::new()),
+        RecursedValue::Object { .. } => (Vec::new(), Vec::with_capacity(8)),
+    };
 
     let mut recursion_stack: SmallVec<[RecursedValue; 8]> = SmallVec::new();
     let partial_active = allow_partial.is_active();

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -320,7 +320,8 @@ enum RecursedValue<'s> {
 /// `base` of zero means nothing else is on that stack — no enclosing container of the same kind
 /// has anything on it yet — so the stack itself is the container and can be handed over whole.
 /// That is the whole document for the common single-container case, where copying it out would be
-/// pure overhead, and the outermost array of a big one, which is the largest copy there is.
+/// pure overhead, and the outermost array of a big one, which would otherwise be the largest
+/// copy of all.
 #[inline]
 fn take_container<T>(stack: &mut Vec<T>, base: usize) -> Vec<T> {
     if base == 0 {
@@ -350,8 +351,13 @@ fn take_value_recursive<'j, 's>(
     // are always the top of the stack, from its `base` up; closing it copies them out into an
     // allocation of exactly the right size. A `Vec` per container has to guess that size instead,
     // and pays a run of reallocations for guessing low.
-    let mut elements: Vec<JsonValue<'s>> = Vec::with_capacity(8);
-    let mut members: Vec<(Cow<'s, str>, JsonValue<'s>)> = Vec::with_capacity(8);
+    // Only the root container's stack is allocated up front; a document that never opens a
+    // container of the other kind never pays for its stack.
+    let (mut elements, mut members): (Vec<JsonValue<'s>>, Vec<(Cow<'s, str>, JsonValue<'s>)>) = match &current_recursion
+    {
+        RecursedValue::Array { .. } => (Vec::with_capacity(8), Vec::new()),
+        RecursedValue::Object { .. } => (Vec::new(), Vec::with_capacity(8)),
+    };
 
     let mut recursion_stack: SmallVec<[RecursedValue; 8]> = SmallVec::new();
     let partial_active = allow_partial.is_active();

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -306,6 +306,15 @@ fn take_value<'j, 's>(
     }
 }
 
+/// A container being parsed, as the position its contents start at in the stack shared by every
+/// container of its kind, see [`take_value_recursive`].
+enum RecursedValue<'s> {
+    /// Array in progress; its elements start at `base` in the shared `elements` stack.
+    Array { base: usize },
+    /// Object in progress; its members start at `base` in the shared `members` stack; `next_key` awaits its value.
+    Object { base: usize, next_key: Cow<'s, str> },
+}
+
 /// The contents of a container that has just closed, taken off the stack they were built on.
 ///
 /// `base` of zero means nothing else is on that stack — no enclosing container of the same kind
@@ -319,13 +328,6 @@ fn take_container<T>(stack: &mut Vec<T>, base: usize) -> Vec<T> {
     } else {
         stack.split_off(base)
     }
-}
-
-/// A container being parsed, as the position its contents start at in the stack shared by every
-/// container of its kind, see [`take_value_recursive`].
-enum RecursedValue<'s> {
-    Array { base: usize },
-    Object { base: usize, next_key: Cow<'s, str> },
 }
 
 #[inline(never)] // this is an iterative algo called only from take_value, no point in inlining

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -351,13 +351,8 @@ fn take_value_recursive<'j, 's>(
     // are always the top of the stack, from its `base` up; closing it copies them out into an
     // allocation of exactly the right size. A `Vec` per container has to guess that size instead,
     // and pays a run of reallocations for guessing low.
-    // Only the root container's stack is allocated up front; a document that never opens a
-    // container of the other kind never pays for its stack.
-    let (mut elements, mut members): (Vec<JsonValue<'s>>, Vec<(Cow<'s, str>, JsonValue<'s>)>) = match &current_recursion
-    {
-        RecursedValue::Array { .. } => (Vec::with_capacity(8), Vec::new()),
-        RecursedValue::Object { .. } => (Vec::new(), Vec::with_capacity(8)),
-    };
+    let mut elements: Vec<JsonValue<'s>> = Vec::new();
+    let mut members: Vec<(Cow<'s, str>, JsonValue<'s>)> = Vec::new();
 
     let mut recursion_stack: SmallVec<[RecursedValue; 8]> = SmallVec::new();
     let partial_active = allow_partial.is_active();

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -252,7 +252,7 @@ fn take_value<'j, 's>(
             };
             take_value_recursive(
                 peek_first,
-                RecursedValue::new_array(),
+                RecursedValue::Array { base: 0 },
                 parser,
                 tape,
                 recursion_limit,
@@ -272,7 +272,10 @@ fn take_value<'j, 's>(
             match parser.peek() {
                 Ok(peek) => take_value_recursive(
                     peek,
-                    RecursedValue::new_object(first_key),
+                    RecursedValue::Object {
+                        base: 0,
+                        next_key: first_key,
+                    },
                     parser,
                     tape,
                     recursion_limit,
@@ -303,25 +306,26 @@ fn take_value<'j, 's>(
     }
 }
 
-enum RecursedValue<'s> {
-    Array(Vec<JsonValue<'s>>),
-    Object {
-        partial: Vec<(Cow<'s, str>, JsonValue<'s>)>,
-        next_key: Cow<'s, str>,
-    },
+/// The contents of a container that has just closed, taken off the stack they were built on.
+///
+/// `base` of zero means nothing else is on that stack — no enclosing container of the same kind
+/// has anything on it yet — so the stack itself is the container and can be handed over whole.
+/// That is the whole document for the common single-container case, where copying it out would be
+/// pure overhead, and the outermost array of a big one, which is the largest copy there is.
+#[inline]
+fn take_container<T>(stack: &mut Vec<T>, base: usize) -> Vec<T> {
+    if base == 0 {
+        std::mem::take(stack)
+    } else {
+        stack.split_off(base)
+    }
 }
 
-impl<'s> RecursedValue<'s> {
-    fn new_array() -> Self {
-        RecursedValue::Array(Vec::with_capacity(8))
-    }
-
-    fn new_object(next_key: Cow<'s, str>) -> Self {
-        RecursedValue::Object {
-            partial: Vec::with_capacity(8),
-            next_key,
-        }
-    }
+/// A container being parsed, as the position its contents start at in the stack shared by every
+/// container of its kind, see [`take_value_recursive`].
+enum RecursedValue<'s> {
+    Array { base: usize },
+    Object { base: usize, next_key: Cow<'s, str> },
 }
 
 #[inline(never)] // this is an iterative algo called only from take_value, no point in inlining
@@ -339,6 +343,14 @@ fn take_value_recursive<'j, 's>(
 ) -> JsonResult<JsonValue<'s>> {
     let recursion_limit: usize = recursion_limit.into();
 
+    // Every array in the document shares one stack of elements, every object one stack of
+    // members. Containers close in the order they opened, so the contents of the one being parsed
+    // are always the top of the stack, from its `base` up; closing it copies them out into an
+    // allocation of exactly the right size. A `Vec` per container has to guess that size instead,
+    // and pays a run of reallocations for guessing low.
+    let mut elements: Vec<JsonValue<'s>> = Vec::with_capacity(8);
+    let mut members: Vec<(Cow<'s, str>, JsonValue<'s>)> = Vec::with_capacity(8);
+
     let mut recursion_stack: SmallVec<[RecursedValue; 8]> = SmallVec::new();
     let partial_active = allow_partial.is_active();
 
@@ -354,7 +366,7 @@ fn take_value_recursive<'j, 's>(
 
     'recursion: loop {
         let mut value = match &mut current_recursion {
-            RecursedValue::Array(array) => {
+            RecursedValue::Array { .. } => {
                 loop {
                     let result = match peek {
                         Peek::True => parser.consume_true().map(|()| JsonValue::Bool(true)),
@@ -366,7 +378,7 @@ fn take_value_recursive<'j, 's>(
                         Peek::Array => {
                             match parser.array_first() {
                                 Ok(Some(first_peek)) => {
-                                    push_recursion!(first_peek, RecursedValue::new_array());
+                                    push_recursion!(first_peek, RecursedValue::Array { base: elements.len() });
                                     // immediately jump to process the first value in the array
                                     continue 'recursion;
                                 }
@@ -379,7 +391,13 @@ fn take_value_recursive<'j, 's>(
                             match parser.object_first::<StringDecoder>(tape) {
                                 Ok(Some(first_key)) => match parser.peek() {
                                     Ok(peek) => {
-                                        push_recursion!(peek, RecursedValue::new_object(create_cow(first_key)));
+                                        push_recursion!(
+                                            peek,
+                                            RecursedValue::Object {
+                                                base: members.len(),
+                                                next_key: create_cow(first_key),
+                                            }
+                                        );
                                         continue 'recursion;
                                     }
                                     Err(e) if !(partial_active && e.allowed_if_partial()) => return Err(e),
@@ -407,12 +425,12 @@ fn take_value_recursive<'j, 's>(
                             }),
                     };
 
-                    let array = match result {
+                    let base = match result {
                         Ok(value) => {
                             // now try to advance position in the current array
                             match parser.array_step() {
                                 Ok(Some(next_peek)) => {
-                                    array.push(value);
+                                    elements.push(value);
                                     peek = next_peek;
                                     // array continuing
                                     continue;
@@ -421,25 +439,25 @@ fn take_value_recursive<'j, 's>(
                                 _ => (),
                             }
 
-                            let RecursedValue::Array(mut array) = current_recursion else {
+                            let RecursedValue::Array { base } = current_recursion else {
                                 unreachable!("known to be in array recursion");
                             };
-                            array.push(value);
-                            array
+                            elements.push(value);
+                            base
                         }
                         Err(e) if !(partial_active && e.allowed_if_partial()) => return Err(e),
                         _ => {
-                            let RecursedValue::Array(array) = current_recursion else {
+                            let RecursedValue::Array { base } = current_recursion else {
                                 unreachable!("known to be in array recursion");
                             };
-                            array
+                            base
                         }
                     };
 
-                    break JsonValue::Array(Arc::new(array));
+                    break JsonValue::Array(Arc::new(take_container(&mut elements, base)));
                 }
             }
-            RecursedValue::Object { partial, next_key } => {
+            RecursedValue::Object { next_key, .. } => {
                 loop {
                     let result = match peek {
                         Peek::True => parser.consume_true().map(|()| JsonValue::Bool(true)),
@@ -451,7 +469,7 @@ fn take_value_recursive<'j, 's>(
                         Peek::Array => {
                             match parser.array_first() {
                                 Ok(Some(first_peek)) => {
-                                    push_recursion!(first_peek, RecursedValue::new_array());
+                                    push_recursion!(first_peek, RecursedValue::Array { base: elements.len() });
                                     // immediately jump to process the first value in the array
                                     continue 'recursion;
                                 }
@@ -464,7 +482,13 @@ fn take_value_recursive<'j, 's>(
                             match parser.object_first::<StringDecoder>(tape) {
                                 Ok(Some(first_key)) => match parser.peek() {
                                     Ok(peek) => {
-                                        push_recursion!(peek, RecursedValue::new_object(create_cow(first_key)));
+                                        push_recursion!(
+                                            peek,
+                                            RecursedValue::Object {
+                                                base: members.len(),
+                                                next_key: create_cow(first_key),
+                                            }
+                                        );
                                         continue 'recursion;
                                     }
                                     Err(e) if !(partial_active && e.allowed_if_partial()) => return Err(e),
@@ -492,7 +516,7 @@ fn take_value_recursive<'j, 's>(
                             }),
                     };
 
-                    let object = match result {
+                    let base = match result {
                         Ok(value) => {
                             // now try to advance position in the current object
                             match parser.object_step::<StringDecoder>(tape) {
@@ -500,7 +524,7 @@ fn take_value_recursive<'j, 's>(
                                     match parser.peek() {
                                         Ok(next_peek) => {
                                             // object continuing
-                                            partial.push((
+                                            members.push((
                                                 std::mem::replace(next_key, create_cow(yet_another_key)),
                                                 value,
                                             ));
@@ -515,22 +539,22 @@ fn take_value_recursive<'j, 's>(
                                 _ => (),
                             }
 
-                            let RecursedValue::Object { mut partial, next_key } = current_recursion else {
+                            let RecursedValue::Object { base, next_key } = current_recursion else {
                                 unreachable!("known to be in object recursion");
                             };
-                            partial.push((next_key, value));
-                            partial
+                            members.push((next_key, value));
+                            base
                         }
                         Err(e) if !(partial_active && e.allowed_if_partial()) => return Err(e),
                         _ => {
-                            let RecursedValue::Object { partial, .. } = current_recursion else {
+                            let RecursedValue::Object { base, .. } = current_recursion else {
                                 unreachable!("known to be in object recursion");
                             };
-                            partial
+                            base
                         }
                     };
 
-                    break JsonValue::Object(Arc::new(object));
+                    break JsonValue::Object(Arc::new(take_container(&mut members, base)));
                 }
             }
         };
@@ -545,26 +569,26 @@ fn take_value_recursive<'j, 's>(
             }
 
             value = match current_recursion {
-                RecursedValue::Array(mut array) => {
-                    array.push(value);
+                RecursedValue::Array { base } => {
+                    elements.push(value);
                     match parser.array_step() {
                         Ok(Some(next_peek)) => {
-                            current_recursion = RecursedValue::Array(array);
+                            current_recursion = RecursedValue::Array { base };
                             break next_peek;
                         }
                         Err(e) if !(partial_active && e.allowed_if_partial()) => return Err(e),
                         _ => (),
                     }
-                    JsonValue::Array(Arc::new(array))
+                    JsonValue::Array(Arc::new(take_container(&mut elements, base)))
                 }
-                RecursedValue::Object { mut partial, next_key } => {
-                    partial.push((next_key, value));
+                RecursedValue::Object { base, next_key } => {
+                    members.push((next_key, value));
 
                     match parser.object_step::<StringDecoder>(tape) {
                         Ok(Some(next_key)) => match parser.peek() {
                             Ok(next_peek) => {
                                 current_recursion = RecursedValue::Object {
-                                    partial,
+                                    base,
                                     next_key: create_cow(next_key),
                                 };
                                 break next_peek;
@@ -576,7 +600,7 @@ fn take_value_recursive<'j, 's>(
                         _ => (),
                     }
 
-                    JsonValue::Object(Arc::new(partial))
+                    JsonValue::Object(Arc::new(take_container(&mut members, base)))
                 }
             }
         };


### PR DESCRIPTION
Prototype, **one of a pair** — the other is #268, which predicts container sizes instead. Both attack the same finding and only one should land; they are open together so CodSpeed can measure them deterministically, which a busy laptop cannot.

## The finding

CodSpeed's flamegraph on #266 put **41.6% of `true_array_jiter_value` in the `realloc` subtree**, reached via `RawVec::grow_one`. A container's `Vec` starts at 8 and doubles, so its final size is guessed at repeatedly and never known until it closes — by which time the guessing has cost a run of reallocations and left capacity nothing will use.

## This approach: don't predict, wait

Every array in a document shares one stack of elements, every object one stack of members. Containers close in the order they opened, so the contents of the one being parsed are always the top of its stack, from `base` up. When it closes the size is finally known, so its contents are copied out into an allocation of exactly the right size — one allocation, no growth, no waste.

`RecursedValue` stops owning a `Vec` and becomes a `base` into the shared stack, which is where the −18% in *allocations* comes from: a container is no longer an allocation until it closes.

Where `base` is zero, nothing else is on that stack, so `take_container` hands the stack over whole rather than copying. That is free for the common single-container document, and skips the largest copy in a nested one — the outermost array. Without it `true_array` regressed 14.6%; with it, 5.1%.

This is what [RapidJSON](https://rapidjson.org/) does with its parse stack, what V8's `JSON.parse` does with its element stack, and what Jackson's `ObjectBuffer` does; simdjson sidesteps the problem entirely by sizing its tape from the input length. The copy this pays per container is the copy doubling already pays on average.

## Measurements

Allocator traffic over the corpus, 2775 documents, via `crates/jiter/examples/alloc_count.rs` (deterministic, unlike timing):

| | allocations | reallocations | bytes requested |
| --- | --- | --- | --- |
| main | 200 423 | 13 537 | 93.9 MB |
| #268 | 200 423 | 7 464 (−45%) | 99.6 MB (+6%) |
| this branch | **164 383 (−18%)** | **6 922 (−49%)** | **68.6 MB (−27%)** |

The only variant that improves all three axes. On `big.json` reallocations go 4957 → 8.

Local timings, **indicative only** — measured on a loaded machine where `x100`, `sentence` and `unicode`, documents containing no containers at all, moved 2–5%:

| benchmark | this branch | #268 |
| --- | --- | --- |
| `big` | **−6.1%** | +0.6% (n.s.) |
| `medium_response` | **−4.1%** (owned −5.3%) | −0.7% |
| `true_array` | +5.1% | **−16.7%** |
| `true_object` | +6.5% | **−10.2%** |
| `string_array` | +7.0% | **−11.3%** |

## The open question

With the steal path, a single-container document allocates exactly as main does — so there is no allocation reason for `true_array` to be slower, and what is left is either per-push overhead from the restructure or the noise floor. CodSpeed counts instructions rather than nanoseconds, so this PR should settle it; the per-tag corpus benchmarks (`json_cases_arrays`, `json_cases_objects`, `json_cases_deep`) say which document shapes move.

## Notes

- All 203 tests pass, including the json-cases corpus and the Python bindings.
- `alloc_count.rs` is measurement scaffolding; it would come out before this landed.