### PR TITLE
Fix partial string parse advancing past the end of the input

### DIFF
--- a/crates/jiter/src/string_decoder.rs
+++ b/crates/jiter/src/string_decoder.rs
@@ -125,7 +125,10 @@ where
             (StringChunk::StringEnd, ascii_only, index) => {
                 let s = to_str(&data[start..index], ascii_only, start, allow_partial)?;
                 // SAFETY: `ascii_only` tracks whether the decoded string contains only ASCII.
-                Ok((unsafe { StringOutput::data(s, ascii_only) }, index_after_string_end(data, index)))
+                Ok((
+                    unsafe { StringOutput::data(s, ascii_only) },
+                    (index + 1).min(data.len()),
+                ))
             }
             (StringChunk::Backslash, ascii_only, index) => {
                 decode_to_tape(data, index, tape, start, ascii_only, allow_partial)
@@ -186,7 +189,7 @@ fn decode_to_tape<'t, 'j>(
         match decode_string_chunk(data, index, ascii_only, allow_partial)? {
             (StringChunk::StringEnd, ascii_only, new_index) => {
                 tape.extend_from_slice(&data[index..new_index]);
-                index = index_after_string_end(data, new_index);
+                index = (new_index + 1).min(data.len());
                 let s = to_str(tape, ascii_only, start, allow_partial)?;
                 // SAFETY: `ascii_only` tracks whether the decoded string contains only ASCII.
                 return Ok((unsafe { StringOutput::tape(s, ascii_only) }, index));
@@ -203,13 +206,6 @@ fn decode_to_tape<'t, 'j>(
 pub(crate) enum StringChunk {
     StringEnd,
     Backslash,
-}
-
-/// In partial mode `decode_string_chunk` reports `StringEnd` at the end of the data even when the
-/// closing quote is missing. Only step over the quote when it is present, so the returned index
-/// never moves past the end of the data.
-fn index_after_string_end(data: &[u8], index: usize) -> usize {
-    if index < data.len() { index + 1 } else { index }
 }
 
 fn to_str(bytes: &[u8], ascii_only: bool, start: usize, allow_partial: bool) -> JsonResult<&str> {
@@ -308,7 +304,7 @@ where
             index = match decode_string_chunk(data, index, true, allow_partial)? {
                 (StringChunk::StringEnd, _, index) => {
                     let r = start..index;
-                    return Ok((r, index_after_string_end(data, index)));
+                    return Ok((r, (index + 1).min(data.len())));
                 }
                 (StringChunk::Backslash, _, index) => index,
             };

--- a/crates/jiter/src/string_decoder.rs
+++ b/crates/jiter/src/string_decoder.rs
@@ -125,7 +125,7 @@ where
             (StringChunk::StringEnd, ascii_only, index) => {
                 let s = to_str(&data[start..index], ascii_only, start, allow_partial)?;
                 // SAFETY: `ascii_only` tracks whether the decoded string contains only ASCII.
-                Ok((unsafe { StringOutput::data(s, ascii_only) }, index + 1))
+                Ok((unsafe { StringOutput::data(s, ascii_only) }, index_after_string_end(data, index)))
             }
             (StringChunk::Backslash, ascii_only, index) => {
                 decode_to_tape(data, index, tape, start, ascii_only, allow_partial)
@@ -186,7 +186,7 @@ fn decode_to_tape<'t, 'j>(
         match decode_string_chunk(data, index, ascii_only, allow_partial)? {
             (StringChunk::StringEnd, ascii_only, new_index) => {
                 tape.extend_from_slice(&data[index..new_index]);
-                index = new_index + 1;
+                index = index_after_string_end(data, new_index);
                 let s = to_str(tape, ascii_only, start, allow_partial)?;
                 // SAFETY: `ascii_only` tracks whether the decoded string contains only ASCII.
                 return Ok((unsafe { StringOutput::tape(s, ascii_only) }, index));
@@ -203,6 +203,13 @@ fn decode_to_tape<'t, 'j>(
 pub(crate) enum StringChunk {
     StringEnd,
     Backslash,
+}
+
+/// In partial mode `decode_string_chunk` reports `StringEnd` at the end of the data even when the
+/// closing quote is missing. Only step over the quote when it is present, so the returned index
+/// never moves past the end of the data.
+fn index_after_string_end(data: &[u8], index: usize) -> usize {
+    if index < data.len() { index + 1 } else { index }
 }
 
 fn to_str(bytes: &[u8], ascii_only: bool, start: usize, allow_partial: bool) -> JsonResult<&str> {
@@ -301,7 +308,7 @@ where
             index = match decode_string_chunk(data, index, true, allow_partial)? {
                 (StringChunk::StringEnd, _, index) => {
                     let r = start..index;
-                    return Ok((r, index + 1));
+                    return Ok((r, index_after_string_end(data, index)));
                 }
                 (StringChunk::Backslash, _, index) => index,
             };

--- a/crates/jiter/tests/main.rs
+++ b/crates/jiter/tests/main.rs
@@ -1693,6 +1693,33 @@ fn jiter_partial_string_escape() {
 }
 
 #[test]
+fn jiter_partial_string_current_index() {
+    // https://github.com/pydantic/jiter/issues/267
+    // a partial string ending at the end of the input must not advance the index past the data
+    let json = br#"["foo"#;
+    let mut jiter = Jiter::new(json).with_allow_partial_strings();
+    assert_eq!(jiter.next_array().unwrap(), Some(Peek::String));
+    let start = jiter.current_index();
+    assert_eq!(jiter.next_str().unwrap(), "foo");
+    assert_eq!(jiter.current_index(), json.len());
+    assert_eq!(jiter.slice_to_current(start), br#""foo"#);
+
+    // same for the tape path (string containing an escape)
+    let json = br#""foo\nbar"#;
+    let mut jiter = Jiter::new(json).with_allow_partial_strings();
+    assert_eq!(jiter.next_str().unwrap(), "foo\nbar");
+    assert_eq!(jiter.current_index(), json.len());
+    assert_eq!(jiter.slice_to_current(0), json.as_slice());
+
+    // same for the range decoder used by next_bytes
+    let json = br#"["bar"#;
+    let mut jiter = Jiter::new(json).with_allow_partial_strings();
+    assert_eq!(jiter.next_array().unwrap(), Some(Peek::String));
+    assert_eq!(jiter.next_bytes().unwrap(), b"bar");
+    assert_eq!(jiter.current_index(), json.len());
+}
+
+#[test]
 fn test_unicode_roundtrip() {
     // '"中文"'
     let json_bytes = b"\"\\u4e2d\\u6587\"";

--- a/crates/jiter/tests/main.rs
+++ b/crates/jiter/tests/main.rs
@@ -1715,8 +1715,43 @@ fn jiter_partial_string_current_index() {
     let json = br#"["bar"#;
     let mut jiter = Jiter::new(json).with_allow_partial_strings();
     assert_eq!(jiter.next_array().unwrap(), Some(Peek::String));
+    let start = jiter.current_index();
     assert_eq!(jiter.next_bytes().unwrap(), b"bar");
     assert_eq!(jiter.current_index(), json.len());
+    assert_eq!(jiter.slice_to_current(start), br#""bar"#);
+}
+
+#[test]
+fn jiter_partial_string_index_never_past_end() {
+    let full =
+        "[\"plain\", \"esc \\n \\u00e9 é tail\", \"ααα\", \"long enough to cross a simd chunk boundary\"]".as_bytes();
+    for use_bytes in [false, true] {
+        for i in 1..=full.len() {
+            let json = &full[..i];
+            let mut jiter = Jiter::new(json).with_allow_partial_strings();
+            let mut peek = jiter.next_array().ok().flatten();
+            while peek.is_some() {
+                let start = jiter.current_index();
+                let value_len = if use_bytes {
+                    jiter.next_bytes().map(<[u8]>::len)
+                } else {
+                    jiter.next_str().map(str::len)
+                };
+                let index = jiter.current_index();
+                assert!(index <= json.len(), "prefix {i}: index {index} > len {}", json.len());
+                // next_bytes rejects an incomplete escape even in partial mode (next_str truncates it
+                // instead). On that error the index must not have moved
+                let Ok(value_len) = value_len else {
+                    assert_eq!(index, start, "prefix {i}");
+                    assert!(jiter.slice_to_current(start).is_empty(), "prefix {i}");
+                    break;
+                };
+                let raw = jiter.slice_to_current(start);
+                assert!(raw.len() > value_len, "prefix {i}: raw {raw:?} shorter than value");
+                peek = jiter.array_step().ok().flatten();
+            }
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #267.

With `with_allow_partial_strings`, parsing a string that runs to the end of the input left `current_index` at `data.len() + 1`. A following `slice_to_current` then panics:

```rust
let data = br#"["foo"#; // 5 bytes, unterminated string
let mut jiter = jiter::Jiter::new(data).with_allow_partial_strings();
jiter.next_array().unwrap();
let start = jiter.current_index();
let s = jiter.next_str().unwrap();       // Ok("foo")
assert!(jiter.current_index() <= data.len()); // fails: 6 > 5
let _ = jiter.slice_to_current(start);   // panics: range end 6 out of range for len 5
```

## Cause

In partial mode `decode_string_chunk` reports `StringEnd` at the end of the data when the closing quote is missing. All three decoder paths in `string_decoder.rs` then advanced `index + 1` as if a quote were there: the direct data path in `StringDecoder::decode`, the tape path in `decode_to_tape`, and `StringDecoderRange::decode`.

## Fix

A helper, `index_after_string_end`, steps over the quote only when `index < data.len()`. After a partial string parse the index now sits at `data.len()`, the same index the existing partial escape paths in `decode_to_tape` already return. When a real closing quote ends the string, `index` points at the quote, so `index < data.len()` always holds and the non-partial path is byte-for-byte unchanged.

With the fix, the reproducer prints `current_index 5` and `slice_to_current` returns `b"\"foo"`.

The regression test covers all three paths: `next_str` on a plain truncated string, `next_str` on a truncated string containing an escape, and `next_bytes` for the range decoder.
