### PR TITLE
ci: build wheels for 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
           # 3.9 can't be run on the arm hardware for PGO
           - os: macos
             target: x86_64
-            interpreter: 3.9 3.10 3.11 3.12 3.13 3.14 graalpy3.11 graalpy3.12
+            interpreter: 3.9 3.10 3.11 3.12 3.13 3.14 3.15 graalpy3.11 graalpy3.12
           - os: macos
             target: aarch64
             interpreter: 3.9 graalpy3.11 graalpy3.12
@@ -400,7 +400,7 @@ jobs:
           - os: windows
             target: aarch64
             runs-on: windows-11-arm
-            interpreter: '3.11 3.12 3.13 3.14 3.14t'
+            interpreter: '3.11 3.12 3.13 3.14 3.14t 3.15 3.15t'
 
     runs-on: ${{ matrix.runs-on || format('{0}-latest', (matrix.os == 'linux' && 'ubuntu') || matrix.os)  }}
     steps:
@@ -423,7 +423,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
-          args: --release --out dist --interpreter ${{ matrix.interpreter || '3.9 3.10 3.11 3.12 3.13 3.14 3.14t' }}
+          args: --release --out dist --interpreter ${{ matrix.interpreter || '3.9 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t' }}
           rust-toolchain: stable
           working-directory: crates/jiter-python
 
@@ -446,7 +446,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [{os: linux, runs-on: ubuntu-latest}, {os: linux_aarch64, runs-on: ubuntu-24.04-arm}, {os: windows, runs-on: windows-latest}, {os: macos, runs-on: macos-latest}]
-        interpreter: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        interpreter: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', '3.15', '3.15t']
         exclude:
           # macos arm only supported from 3.10 and up
           - platform:
@@ -651,7 +651,7 @@ jobs:
         id: setup-python
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           enable-cache: true # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
 
       - name: get dist artifacts
@@ -745,7 +745,7 @@ jobs:
       - test-builds-arch
       - test-builds-os
       - build-sdist
-      - build-wasm-emscripten
+      - test-pyemscripten
     if: success() && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: release-python

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-pyo3 = { version = "0.29.0" }
-pyo3-build-config = { version = "0.29.0" }
+pyo3 = { version = "0.29.2" }
+pyo3-build-config = { version = "0.29.2" }

--- a/crates/jiter-python/pyproject.toml
+++ b/crates/jiter-python/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: GraalPy",
     "Intended Audience :: Developers",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Python 3.15 wheel builds (including free-threaded variants) and bump `pyo3` to 0.29.2 to enable 3.15 compatibility and packaging.

- Extend CI matrices and default maturin args to include 3.15/`3.15t` across Linux, macOS (x86_64), and Windows (incl. aarch64).
- Update `Cargo.toml` to `pyo3`/`pyo3-build-config` 0.29.2 and advertise 3.15 in `pyproject.toml` classifiers.
- Use Python 3.14 for the `setup-uv` step in CI.
- Release workflow now gates on `test-pyemscripten` (replaces `build-wasm-emscripten`).

<sup>Written for commit 099014de3fd607fc3f6d5419e7f237d2fd01eea7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

