### PR TITLE
reduce unsafety & ub

### DIFF
--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -248,7 +248,7 @@ impl IntParse {
         };
 
         index += 1;
-        let (chunk, new_index) = IntChunk::parse_small(data, index, first_value);
+        let (chunk, new_index) = decode_int_chunk_small(data, index, first_value);
 
         let ongoing: u64 = match chunk {
             IntChunk::Ongoing(value) => value,
@@ -306,7 +306,7 @@ impl IntParse {
             index = new_index;
 
             loop {
-                let (chunk, new_index) = IntChunk::parse_big(data, index);
+                let (chunk, new_index) = decode_int_chunk_big(data, index);
                 if (new_index - start) > 4300 {
                     return json_err!(NumberOutOfRange, start + 4301);
                 }
@@ -335,18 +335,6 @@ pub(crate) enum IntChunk {
     Ongoing(u64),
     Done(u64),
     Float,
-}
-
-impl IntChunk {
-    #[inline(always)]
-    fn parse_small(data: &[u8], index: usize, value: u64) -> (Self, usize) {
-        decode_int_chunk_small(data, index, value)
-    }
-
-    #[inline(always)]
-    fn parse_big(data: &[u8], index: usize) -> (Self, usize) {
-        decode_int_chunk_big(data, index)
-    }
 }
 
 pub(crate) static INT_CHAR_MAP: [bool; 256] = {
@@ -460,7 +448,7 @@ impl AbstractNumberDecoder for NumberRange {
             return Ok((Self::int(start..index), index));
         }
         loop {
-            let (chunk, new_index) = IntChunk::parse_big(data, index);
+            let (chunk, new_index) = decode_int_chunk_big(data, index);
             if (new_index - start) > 4300 {
                 return json_err!(NumberOutOfRange, start + 4301);
             }

--- a/crates/jiter/src/py_string_cache.rs
+++ b/crates/jiter/src/py_string_cache.rs
@@ -56,7 +56,7 @@ pub struct StringCacheAll;
 
 impl StringMaybeCache for StringCacheAll {
     fn get_key<'py>(py: Python<'py>, string_output: StringOutput<'_, '_>) -> Bound<'py, PyString> {
-        // Safety: string_output carries the safety information
+        // SAFETY: `StringOutput` guarantees that its ASCII flag matches its contents.
         unsafe { cached_py_string_maybe_ascii(py, string_output.as_str(), string_output.ascii_only()) }
     }
 }
@@ -65,11 +65,12 @@ pub struct StringCacheKeys;
 
 impl StringMaybeCache for StringCacheKeys {
     fn get_key<'py>(py: Python<'py>, string_output: StringOutput<'_, '_>) -> Bound<'py, PyString> {
-        // Safety: string_output carries the safety information
+        // SAFETY: `StringOutput` guarantees that its ASCII flag matches its contents.
         unsafe { cached_py_string_maybe_ascii(py, string_output.as_str(), string_output.ascii_only()) }
     }
 
     fn get_value<'py>(py: Python<'py>, string_output: StringOutput<'_, '_>) -> Bound<'py, PyString> {
+        // SAFETY: `StringOutput` guarantees that its ASCII flag matches its contents.
         unsafe { pystring_fast_new_maybe_ascii(py, string_output.as_str(), string_output.ascii_only()) }
     }
 }
@@ -78,6 +79,7 @@ pub struct StringNoCache;
 
 impl StringMaybeCache for StringNoCache {
     fn get_key<'py>(py: Python<'py>, string_output: StringOutput<'_, '_>) -> Bound<'py, PyString> {
+        // SAFETY: `StringOutput` guarantees that its ASCII flag matches its contents.
         unsafe { pystring_fast_new_maybe_ascii(py, string_output.as_str(), string_output.ascii_only()) }
     }
 }
@@ -108,7 +110,7 @@ pub fn cache_clear() {
 /// Create a cached Python `str` from a string slice
 #[inline]
 pub fn cached_py_string<'py>(py: Python<'py>, s: &str) -> Bound<'py, PyString> {
-    // SAFETY: not setting ascii-only
+    // SAFETY: the ASCII fast path is disabled.
     unsafe { cached_py_string_maybe_ascii(py, s, false) }
 }
 
@@ -119,7 +121,7 @@ pub fn cached_py_string<'py>(py: Python<'py>, s: &str) -> Bound<'py, PyString> {
 /// Caller must pass ascii-only string.
 #[inline]
 pub unsafe fn cached_py_string_ascii<'py>(py: Python<'py>, s: &str) -> Bound<'py, PyString> {
-    // SAFETY: caller upholds invariant
+    // SAFETY: the caller guarantees that `s` is ASCII only.
     unsafe { cached_py_string_maybe_ascii(py, s, true) }
 }
 
@@ -127,6 +129,7 @@ pub unsafe fn cached_py_string_ascii<'py>(py: Python<'py>, s: &str) -> Bound<'py
 ///
 /// Caller must match the ascii_only flag to the string passed in.
 unsafe fn cached_py_string_maybe_ascii<'py>(py: Python<'py>, s: &str, ascii_only: bool) -> Bound<'py, PyString> {
+    // SAFETY: this function's caller guarantees that `ascii_only` matches `s`.
     unsafe {
         // from tests, 0 and 1 character strings are faster not cached
         if (2..64).contains(&s.len()) {
@@ -231,7 +234,7 @@ impl PyStringCache {
     }
 }
 
-/// Creatate a new Python `str` from a string slice, with a fast path for ASCII strings
+/// Create a new Python `str` from a string slice, with a fast path for ASCII strings
 ///
 /// # Safety
 ///
@@ -255,13 +258,18 @@ pub unsafe fn pystring_ascii_new<'py>(py: Python<'py>, s: &str) -> Bound<'py, Py
     unsafe {
         #[cfg(not(any(PyPy, GraalPy, Py_LIMITED_API)))]
         {
-            let ptr = pyo3::ffi::PyUnicode_New(s.len() as isize, 127);
+            // SAFETY: `PyUnicode_New` returns a new owned reference or null. Converting it to a
+            // `Bound` immediately ensures an allocation failure is handled before dereferencing it.
+            let py_string = Bound::from_owned_ptr(py, pyo3::ffi::PyUnicode_New(s.len() as isize, 127));
+            let ptr = py_string.as_ptr();
             // see https://github.com/pydantic/jiter/pull/72#discussion_r1545485907
             debug_assert_eq!(pyo3::ffi::PyUnicode_KIND(ptr), pyo3::ffi::PyUnicode_1BYTE_KIND);
             let data_ptr = pyo3::ffi::PyUnicode_DATA(ptr).cast();
+            // SAFETY: the caller guarantees that `s` is ASCII, so `PyUnicode_New` allocated a
+            // writable one-byte buffer containing `s.len()` bytes followed by a null terminator.
             core::ptr::copy_nonoverlapping(s.as_ptr(), data_ptr, s.len());
             core::ptr::write(data_ptr.add(s.len()), 0);
-            Bound::from_owned_ptr(py, ptr).cast_into_unchecked()
+            py_string.cast_into_unchecked()
         }
 
         #[cfg(any(PyPy, GraalPy, Py_LIMITED_API))]

--- a/crates/jiter/src/python.rs
+++ b/crates/jiter/src/python.rs
@@ -188,10 +188,12 @@ impl<StringCache: StringMaybeCache, KeyCheck: MaybeKeyCheck, ParseNumber: MaybeP
 
     fn parse_object<'py>(&mut self, py: Python<'py>, dict: &Bound<'py, PyDict>) -> JsonResult<()> {
         let set_item = |key: Bound<'py, PyString>, value: Bound<'py, PyAny>| {
+            // SAFETY: all pointers come from live `Bound` objects, the GIL is held, and
+            // `PyDict_SetItem` does not steal references to the key or value.
             let r = unsafe { ffi::PyDict_SetItem(dict.as_ptr(), key.as_ptr(), value.as_ptr()) };
-            // AFAIK this shouldn't happen since the key will always be a string  which is hashable
-            // we panic here rather than returning a result and using `?` below as it's up to 14% faster
-            // presumably because there are fewer branches
+            // The key is always a hashable string, so this can only realistically fail on allocation.
+            // We panic rather than returning a result and using `?` below as it's up to 14% faster,
+            // presumably because there are fewer branches.
             assert_ne!(r, -1, "PyDict_SetItem failed");
         };
         let mut check_keys = KeyCheck::default();

--- a/crates/jiter/src/simd/aarch64.rs
+++ b/crates/jiter/src/simd/aarch64.rs
@@ -203,36 +203,20 @@ const BACKSLASH_16: SimdVecu8_16 = simd_const!([b'\\'; 16]);
 const CONTROL_16: SimdVecu8_16 = simd_const!([32u8; 16]);
 const ASCII_MAX_16: SimdVecu8_16 = simd_const!([127u8; 16]);
 
+#[inline(always)]
 pub(crate) fn decode_string_chunk(
-    data: &[u8],
-    index: usize,
-    ascii_only: bool,
-    allow_partial: bool,
-) -> JsonResult<(StringChunk, bool, usize)> {
-    #[cfg(target_arch = "aarch64")]
-    {
-        // SAFETY: all supported aarch64 targets support neon intrinsics
-        unsafe { decode_string_chunk_fast(data, index, ascii_only, allow_partial) }
-    }
-    #[cfg(not(target_arch = "aarch64"))]
-    {
-        super::fallback_string::decode_string_chunk(data, index, ascii_only, allow_partial)
-    }
-}
-
-#[target_feature(enable = "neon")]
-fn decode_string_chunk_fast(
     data: &[u8],
     mut index: usize,
     mut ascii_only: bool,
     allow_partial: bool,
 ) -> JsonResult<(StringChunk, bool, usize)> {
-    #[cfg(target_feature = "neon")]
+    #[cfg(target_arch = "aarch64")]
     while let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
         let byte_chunk: &[u8; SIMD_STEP] = byte_chunk.try_into().unwrap();
         let byte_vec = load_slice(byte_chunk);
 
-        let ascii_mask = string_ascii_mask(byte_vec);
+        // SAFETY: all supported aarch64 targets support neon intrinsics
+        let ascii_mask = unsafe { string_ascii_mask(byte_vec) };
         if is_zero(ascii_mask) {
             // this chunk is just ascii, continue to the next chunk
             index += SIMD_STEP;

--- a/crates/jiter/src/simd/aarch64.rs
+++ b/crates/jiter/src/simd/aarch64.rs
@@ -54,6 +54,7 @@ const SIMD_STEP: usize = 16;
 
 macro_rules! simd_const {
     ($array:expr) => {
+        // SAFETY: callers transmute arrays to SIMD vectors of the same size and element type.
         unsafe { transmute($array) }
     };
 }
@@ -73,15 +74,16 @@ const ALT_MUL_U8_16: SimdVecu8_16 = simd_const!([
 const ALT_MUL_U16_8: SimdVecu16_8 = simd_const!([100u16, 1u16, 100u16, 1u16, 100u16, 1u16, 100u16, 1u16]);
 const ALT_MUL_U32_4: SimdVecu32_4 = simd_const!([10000u32, 1u32, 10000u32, 1u32]);
 
-#[inline(always)]
+#[target_feature(enable = "neon")]
 pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usize) {
     if let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
+        let byte_chunk: &[u8; SIMD_STEP] = byte_chunk.try_into().unwrap();
         let byte_vec = load_slice(byte_chunk);
 
         let digit_mask = get_digit_mask(byte_vec);
         if is_zero(digit_mask) {
             // all lanes are digits, parse the full vector
-            let value = unsafe { full_calc(byte_vec, 16) };
+            let value = full_calc(byte_vec, 16);
             (IntChunk::Ongoing(value), index + SIMD_STEP)
         } else {
             // some lanes are not digits, transmute to a pair of u64 and find the first non-digit
@@ -91,11 +93,12 @@ pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usiz
                 (IntChunk::Float, index)
             } else if last_digit <= 8 {
                 // none-digit in the first 8 bytes
-                let value = unsafe { first_half_calc(byte_vec, last_digit) };
+                let value = first_half_calc(byte_vec, last_digit);
                 (IntChunk::Done(value), index)
             } else {
                 // none-digit in the last 8 bytes
-                let value = unsafe { full_calc(byte_vec, last_digit) };
+                // SAFETY: `last_digit` is in 9..=15 and all preceding lanes are digits.
+                let value = full_calc(byte_vec, last_digit);
                 (IntChunk::Done(value), index)
             }
         }
@@ -106,88 +109,90 @@ pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usiz
 }
 
 #[rustfmt::skip]
+#[target_feature(enable = "neon")]
 fn get_digit_mask(byte_vec: SimdVecu8_16) -> SimdVecu8_16 {
-    unsafe {
-        simd_or_16(
-            simd_lt_16(byte_vec, ZERO_DIGIT_16),
-            simd_gt_16(byte_vec, NINE_DIGIT_16),
-        )
-    }
+    simd_or_16(
+        simd_lt_16(byte_vec, ZERO_DIGIT_16),
+        simd_gt_16(byte_vec, NINE_DIGIT_16),
+    )
 }
 
-unsafe fn first_half_calc(byte_vec: SimdVecu8_16, last_digit: u32) -> u64 {
-    unsafe {
-        let small_byte_vec = simd_get_low(byte_vec);
-        // subtract ascii '0' from every byte to get the digit values
-        let digits: SimdVecu8_8 = simd_sub_8(small_byte_vec, ZERO_DIGIT_U8_8);
-        let digits = match last_digit {
-            0 => return 0,
-            1 => {
-                let t: [u8; 8] = transmute(digits);
-                return t[0] as u64;
-            }
-            2 => combine_vecs_8::<2>(ZERO_VAL_U8_8, digits),
-            3 => combine_vecs_8::<3>(ZERO_VAL_U8_8, digits),
-            4 => combine_vecs_8::<4>(ZERO_VAL_U8_8, digits),
-            5 => combine_vecs_8::<5>(ZERO_VAL_U8_8, digits),
-            6 => combine_vecs_8::<6>(ZERO_VAL_U8_8, digits),
-            7 => combine_vecs_8::<7>(ZERO_VAL_U8_8, digits),
-            8 => digits,
-            _ => unreachable!("last_digit should be less than 8"),
-        };
-        // multiple every other digit by 10
-        let x: SimdVecu8_8 = simd_mul_8(digits, ALT_MUL_U8_8);
-        // add the value together and combine the 8x8-bit lanes into 4x16-bit lanes
-        let x: SimdVecu16_4 = simd_add_8(x);
-        // multiple every other digit by 100
-        let x: SimdVecu16_4 = simd_mul_u16_4(x, ALT_MUL_U16_4);
-        // add the value together and combine the 4x16-bit lanes into 2x32-bit lanes
-        let x: SimdVecu32_2 = simd_add_u16_4(x);
-        // multiple the first value 10000
-        let x: SimdVecu32_2 = simd_mul_u32_2(x, ALT_MUL_U32_2);
-        // add the value together and combine the 2x32-bit lanes into 1x64-bit lane
-        let x: SimdVecu64_1 = simd_add_u32_2(x);
-        // transmute the 64-bit lane into a u64
-        transmute(x)
-    }
+#[target_feature(enable = "neon")]
+fn first_half_calc(byte_vec: SimdVecu8_16, last_digit: u32) -> u64 {
+    let small_byte_vec = simd_get_low(byte_vec);
+    // subtract ascii '0' from every byte to get the digit values
+    let digits: SimdVecu8_8 = simd_sub_8(small_byte_vec, ZERO_DIGIT_U8_8);
+    let digits = match last_digit {
+        0 => return 0,
+        1 => {
+            // SAFETY: transmute the 8x8-bit lanes into an array;
+            let t: [u8; 8] = unsafe { transmute(digits) };
+            return t[0] as u64;
+        }
+        2 => combine_vecs_8::<2>(ZERO_VAL_U8_8, digits),
+        3 => combine_vecs_8::<3>(ZERO_VAL_U8_8, digits),
+        4 => combine_vecs_8::<4>(ZERO_VAL_U8_8, digits),
+        5 => combine_vecs_8::<5>(ZERO_VAL_U8_8, digits),
+        6 => combine_vecs_8::<6>(ZERO_VAL_U8_8, digits),
+        7 => combine_vecs_8::<7>(ZERO_VAL_U8_8, digits),
+        8 => digits,
+        _ => unreachable!("last_digit should be less than 8"),
+    };
+    // multiple every other digit by 10
+    let x: SimdVecu8_8 = simd_mul_8(digits, ALT_MUL_U8_8);
+    // add the value together and combine the 8x8-bit lanes into 4x16-bit lanes
+    let x: SimdVecu16_4 = simd_add_8(x);
+    // multiple every other digit by 100
+    let x: SimdVecu16_4 = simd_mul_u16_4(x, ALT_MUL_U16_4);
+    // add the value together and combine the 4x16-bit lanes into 2x32-bit lanes
+    let x: SimdVecu32_2 = simd_add_u16_4(x);
+    // multiple the first value 10000
+    let x: SimdVecu32_2 = simd_mul_u32_2(x, ALT_MUL_U32_2);
+    // add the value together and combine the 2x32-bit lanes into 1x64-bit lane
+    let x: SimdVecu64_1 = simd_add_u32_2(x);
+    // SAFETY: transmute the 64-bit lane into a u64
+    unsafe { transmute(x) }
 }
 
-unsafe fn full_calc(byte_vec: SimdVecu8_16, last_digit: u32) -> u64 {
-    unsafe {
-        // subtract ascii '0' from every byte to get the digit values
-        let digits: SimdVecu8_16 = simd_sub_16(byte_vec, ZERO_DIGIT_16);
-        let digits = match last_digit {
-            9 => combine_vecs_16::<9>(ZERO_VAL_U8_16, digits),
-            10 => combine_vecs_16::<10>(ZERO_VAL_U8_16, digits),
-            11 => combine_vecs_16::<11>(ZERO_VAL_U8_16, digits),
-            12 => combine_vecs_16::<12>(ZERO_VAL_U8_16, digits),
-            13 => combine_vecs_16::<13>(ZERO_VAL_U8_16, digits),
-            14 => combine_vecs_16::<14>(ZERO_VAL_U8_16, digits),
-            15 => combine_vecs_16::<15>(ZERO_VAL_U8_16, digits),
-            16 => digits,
-            _ => unreachable!("last_digit should be between 9 and 16"),
-        };
-        // multiple every other digit by 10
-        let x: SimdVecu8_16 = simd_mul_16(digits, ALT_MUL_U8_16);
-        // add the value together and combine the 16x8-bit lanes into 8x16-bit lanes
-        let x: SimdVecu16_8 = simd_add_16(x);
-        // multiple every other digit by 100
-        let x: SimdVecu16_8 = simd_mul_u16_8(x, ALT_MUL_U16_8);
-        // add the value together and combine the 8x16-bit lanes into 4x32-bit lanes
-        let x: SimdVecu32_4 = simd_add_u16_8(x);
-        // multiple every other digit by 10000
-        let x: SimdVecu32_4 = simd_mul_u32_4(x, ALT_MUL_U32_4);
-        // add the value together and combine the 4x32-bit lanes into 2x64-bit lane
-        let x: SimdVecu64_2 = simd_add_u32_4(x);
+/// # Safety
+///
+/// `last_digit` must be in `9..=16`, and all preceding lanes must contain ASCII digits.
+#[target_feature(enable = "neon")]
+fn full_calc(byte_vec: SimdVecu8_16, last_digit: u32) -> u64 {
+    // subtract ascii '0' from every byte to get the digit values
+    let digits: SimdVecu8_16 = simd_sub_16(byte_vec, ZERO_DIGIT_16);
+    let digits = match last_digit {
+        9 => combine_vecs_16::<9>(ZERO_VAL_U8_16, digits),
+        10 => combine_vecs_16::<10>(ZERO_VAL_U8_16, digits),
+        11 => combine_vecs_16::<11>(ZERO_VAL_U8_16, digits),
+        12 => combine_vecs_16::<12>(ZERO_VAL_U8_16, digits),
+        13 => combine_vecs_16::<13>(ZERO_VAL_U8_16, digits),
+        14 => combine_vecs_16::<14>(ZERO_VAL_U8_16, digits),
+        15 => combine_vecs_16::<15>(ZERO_VAL_U8_16, digits),
+        16 => digits,
+        _ => unreachable!("last_digit should be between 9 and 16"),
+    };
+    // multiple every other digit by 10
+    let x: SimdVecu8_16 = simd_mul_16(digits, ALT_MUL_U8_16);
+    // add the value together and combine the 16x8-bit lanes into 8x16-bit lanes
+    let x: SimdVecu16_8 = simd_add_16(x);
+    // multiple every other digit by 100
+    let x: SimdVecu16_8 = simd_mul_u16_8(x, ALT_MUL_U16_8);
+    // add the value together and combine the 8x16-bit lanes into 4x32-bit lanes
+    let x: SimdVecu32_4 = simd_add_u16_8(x);
+    // multiple every other digit by 10000
+    let x: SimdVecu32_4 = simd_mul_u32_4(x, ALT_MUL_U32_4);
+    // add the value together and combine the 4x32-bit lanes into 2x64-bit lane
+    let x: SimdVecu64_2 = simd_add_u32_4(x);
 
-        // transmute the 2x64-bit lane into an array;
-        let t: [u64; 2] = transmute(x);
-        // since the data started out as digits, it's safe to assume the result fits in a u64
-        t[0].wrapping_mul(100_000_000).wrapping_add(t[1])
-    }
+    // SAFETY: transmute the 2x64-bit lane into an array;
+    let t: [u64; 2] = unsafe { transmute(x) };
+    // since the data started out as digits, it's safe to assume the result fits in a u64
+    t[0].wrapping_mul(100_000_000).wrapping_add(t[1])
 }
 
 fn next_is_float(data: &[u8], index: usize) -> bool {
+    // SAFETY: callers derive `index` from the first non-digit lane in a loaded 16-byte chunk.
     let next = unsafe { data.get_unchecked(index) };
     matches!(next, b'.' | b'e' | b'E')
 }
@@ -198,14 +203,33 @@ const BACKSLASH_16: SimdVecu8_16 = simd_const!([b'\\'; 16]);
 const CONTROL_16: SimdVecu8_16 = simd_const!([32u8; 16]);
 const ASCII_MAX_16: SimdVecu8_16 = simd_const!([127u8; 16]);
 
-#[inline(always)]
 pub(crate) fn decode_string_chunk(
+    data: &[u8],
+    index: usize,
+    ascii_only: bool,
+    allow_partial: bool,
+) -> JsonResult<(StringChunk, bool, usize)> {
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: all supported aarch64 targets support neon intrinsics
+        unsafe { decode_string_chunk_fast(data, index, ascii_only, allow_partial) }
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        super::fallback_string::decode_string_chunk(data, index, ascii_only, allow_partial)
+    }
+}
+
+#[target_feature(enable = "neon")]
+fn decode_string_chunk_fast(
     data: &[u8],
     mut index: usize,
     mut ascii_only: bool,
     allow_partial: bool,
 ) -> JsonResult<(StringChunk, bool, usize)> {
+    #[cfg(target_feature = "neon")]
     while let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
+        let byte_chunk: &[u8; SIMD_STEP] = byte_chunk.try_into().unwrap();
         let byte_vec = load_slice(byte_chunk);
 
         let ascii_mask = string_ascii_mask(byte_vec);
@@ -214,6 +238,7 @@ pub(crate) fn decode_string_chunk(
             index += SIMD_STEP;
         } else {
             // this chunk contains either a stop character or a non-ascii character
+            // SAFETY: the SIMD vector and byte array are both 16 bytes.
             let a: [u8; 16] = unsafe { transmute(byte_vec) };
             #[allow(clippy::redundant_else)]
             if let Some(r) = super::fallback_string::decode_array(a, &mut index, ascii_only) {
@@ -228,24 +253,24 @@ pub(crate) fn decode_string_chunk(
 }
 
 #[rustfmt::skip]
+#[target_feature(enable = "neon")]
 /// returns a mask where any non-zero byte means we don't have a simple ascii character, either
 /// quote, backslash, control character, or non-ascii (above 127)
 fn string_ascii_mask(byte_vec: SimdVecu8_16) -> SimdVecu8_16 {
-    unsafe {
+    simd_or_16(
+        simd_eq_16(byte_vec, QUOTE_16),
         simd_or_16(
-            simd_eq_16(byte_vec, QUOTE_16),
+            simd_eq_16(byte_vec, BACKSLASH_16),
             simd_or_16(
-                simd_eq_16(byte_vec, BACKSLASH_16),
-                simd_or_16(
-                    simd_gt_16(byte_vec, ASCII_MAX_16),
-                    simd_lt_16(byte_vec, CONTROL_16),
-                )
+                simd_gt_16(byte_vec, ASCII_MAX_16),
+                simd_lt_16(byte_vec, CONTROL_16),
             )
         )
-    }
+    )
 }
 
 fn find_end(digit_mask: SimdVecu8_16) -> u32 {
+    // SAFETY: the SIMD vector and integer array are both 16 bytes.
     let t: [u64; 2] = unsafe { transmute(digit_mask) };
     if t[0] != 0 {
         // non-digit in the first 8 bytes
@@ -257,11 +282,12 @@ fn find_end(digit_mask: SimdVecu8_16) -> u32 {
 
 /// return true if all bytes are zero
 fn is_zero(vec: SimdVecu8_16) -> bool {
+    // SAFETY: the SIMD vector and integer array are both 16 bytes.
     let t: [u64; 2] = unsafe { transmute(vec) };
     t[0] == 0 && t[1] == 0
 }
 
-fn load_slice(bytes: &[u8]) -> SimdVecu8_16 {
-    debug_assert_eq!(bytes.len(), 16);
+fn load_slice(bytes: &[u8; SIMD_STEP]) -> SimdVecu8_16 {
+    // SAFETY: the array reference is valid for reading 16 contiguous bytes.
     unsafe { simd_load_16(bytes.as_ptr()) }
 }

--- a/crates/jiter/src/simd/mod.rs
+++ b/crates/jiter/src/simd/mod.rs
@@ -15,7 +15,8 @@ use crate::number_decoder::IntChunk;
 pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usize) {
     #[cfg(target_arch = "aarch64")]
     {
-        aarch64::decode_int_chunk_big(data, index)
+        // SAFETY: all supported aarch64 targets support neon intrinsics
+        unsafe { aarch64::decode_int_chunk_big(data, index) }
     }
     #[cfg(not(target_arch = "aarch64"))]
     {

--- a/crates/jiter/src/string_decoder.rs
+++ b/crates/jiter/src/string_decoder.rs
@@ -75,7 +75,7 @@ mod string_output {
     {
         /// # Safety
         ///
-        /// `accii_only` must only be set to true if the string is ascii only
+        /// `ascii_only` must only be set to true if the string is ASCII only
         pub unsafe fn tape(data: &'t str, ascii_only: bool) -> Self {
             StringOutput {
                 data: StringOutputType::Tape(data),
@@ -85,7 +85,7 @@ mod string_output {
 
         /// # Safety
         ///
-        /// `accii_only` must only be set to true if the string is ascii only
+        /// `ascii_only` must only be set to true if the string is ASCII only
         pub unsafe fn data(data: &'j str, ascii_only: bool) -> Self {
             StringOutput {
                 data: StringOutputType::Data(data),
@@ -124,6 +124,7 @@ where
         match decode_string_chunk(data, start, true, allow_partial)? {
             (StringChunk::StringEnd, ascii_only, index) => {
                 let s = to_str(&data[start..index], ascii_only, start, allow_partial)?;
+                // SAFETY: `ascii_only` tracks whether the decoded string contains only ASCII.
                 Ok((unsafe { StringOutput::data(s, ascii_only) }, index + 1))
             }
             (StringChunk::Backslash, ascii_only, index) => {
@@ -164,6 +165,7 @@ fn decode_to_tape<'t, 'j>(
                     Err(e) => {
                         if allow_partial && e.error_type == JsonErrorType::EofWhileParsingString {
                             let s = to_str(tape, ascii_only, start, allow_partial)?;
+                            // SAFETY: `ascii_only` tracks whether the decoded string contains only ASCII.
                             return Ok((unsafe { StringOutput::tape(s, ascii_only) }, e.index));
                         }
                         return Err(e);
@@ -175,6 +177,7 @@ fn decode_to_tape<'t, 'j>(
         } else {
             if allow_partial {
                 let s = to_str(tape, ascii_only, start, allow_partial)?;
+                // SAFETY: `ascii_only` tracks whether the decoded string contains only ASCII.
                 return Ok((unsafe { StringOutput::tape(s, ascii_only) }, index));
             }
             return json_err!(EofWhileParsingString, index);
@@ -185,6 +188,7 @@ fn decode_to_tape<'t, 'j>(
                 tape.extend_from_slice(&data[index..new_index]);
                 index = new_index + 1;
                 let s = to_str(tape, ascii_only, start, allow_partial)?;
+                // SAFETY: `ascii_only` tracks whether the decoded string contains only ASCII.
                 return Ok((unsafe { StringOutput::tape(s, ascii_only) }, index));
             }
             (StringChunk::Backslash, ascii_only_new, index_new) => {

--- a/crates/jiter/tests/python.rs
+++ b/crates/jiter/tests/python.rs
@@ -74,6 +74,7 @@ fn test_cache_into() {
 fn test_pystring_ascii_new() {
     let json = "100abc";
     Python::attach(|py| {
+        // SAFETY: `json` contains only ASCII characters.
         let s = unsafe { pystring_ascii_new(py, json) };
         assert_eq!(s.to_string(), "100abc");
     });


### PR DESCRIPTION
Fixes #261 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces undefined behavior and narrows unsafe usage across `jiter` with no observable behavior change or expected perf impact. Old code used unchecked transmutes, untyped SIMD loads, and implicit NEON; new code gates NEON, uses typed `[u8; 16]` loads, and documents/codifies invariants. Fixes #261.

- AArch64 SIMD: mark hot paths with `#[target_feature(enable = "neon")]` and assert support at call sites; require `&[u8; 16]` for loads; simplify integer parsing by removing `IntChunk::parse_*` wrappers in favor of `decode_int_chunk_*`, and make `first_half_calc`/`full_calc` safe; string fast path now guarded on aarch64 with safe fallback elsewhere.
- Python interop and strings: build a `Bound<PyString>` from `PyUnicode_New` before writes; clarify `PyDict_SetItem` safety (no ref stealing; panics only on allocation failure); thread and enforce the `ascii_only` invariant via `StringOutput` and update safety docs.

<sup>Written for commit 81ad66523099b4850c70372e391e5f3652865698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

