### PR TITLE
ci: use deterministic seed for "big" benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 permissions: {}
 
 env:
+  JITER_BENCH_SEED: '0'
   # the json-cases corpus the json_cases test and benchmark run over; pinned so that a commit there
   # can't turn this repository's CI red, and so the benchmark numbers stay comparable between runs
   JSON_CASES_REF: fa6c17fbabf775b8099a0ed5f32cfc733700cedc # 2026-08-19, `size` and `tags` in cases.json

--- a/crates/jiter/benches/README.md
+++ b/crates/jiter/benches/README.md
@@ -6,6 +6,8 @@ Before running benchmarks, make sure to generate `big.json`:
 python3 ./crates/jiter/benches/generate_big.py
 ```
 
+Set `JITER_BENCH_SEED` to reproduce the generated data. If it is unset, each invocation generates a new dataset.
+
 To run benchmarks, run:
 
 ```shell

--- a/crates/jiter/benches/generate_big.py
+++ b/crates/jiter/benches/generate_big.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 import json
+import os
 from pathlib import Path
-from random import random
+from random import Random
 
 THIS_DIR = Path(__file__).parent
+
+random = Random(os.environ.get("JITER_BENCH_SEED")).random
 
 data = []
 no_strings = True

--- a/crates/jiter/benches/generate_big.py
+++ b/crates/jiter/benches/generate_big.py
@@ -6,7 +6,7 @@ from random import Random
 
 THIS_DIR = Path(__file__).parent
 
-random = Random(os.environ.get("JITER_BENCH_SEED")).random
+random = Random(os.environ.get('JITER_BENCH_SEED')).random
 
 data = []
 no_strings = True


### PR DESCRIPTION
As identified in https://github.com/pydantic/jiter/pull/276#issuecomment-5397594084

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds the "big" benchmark data generator via `JITER_BENCH_SEED` so CI and local runs can reproduce results. Previously each run produced different data; with a seed, output is deterministic, stabilizing benchmark comparisons.

- CI exports `JITER_BENCH_SEED='0'` in `.github/workflows/ci.yml`.
- Locally, set `JITER_BENCH_SEED` before running `generate_big.py`; if unset, each run generates a new dataset.
- Benchmark logic is unchanged; only input data becomes deterministic when seeded.

<sup>Written for commit fcf2f7547f879d44c910a5123929e8bd5b035326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

