### PR TITLE
Fix next_bytes erroring on truncated escapes in partial mode

### DIFF
--- a/crates/jiter/src/string_decoder.rs
+++ b/crates/jiter/src/string_decoder.rs
@@ -306,13 +306,20 @@ where
                 match next_inner {
                     // these escapes are easy to validate
                     b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't' => (),
-                    b'u' => {
-                        let (_, new_index) = parse_escape(data, index)?;
-                        index = new_index;
-                    }
+                    b'u' => match parse_escape(data, index) {
+                        Ok((_, new_index)) => index = new_index,
+                        // input ends inside the `\u` escape, keep the span before the backslash
+                        Err(e) if allow_partial && e.error_type == JsonErrorType::EofWhileParsingString => {
+                            return Ok((start..index - 1, e.index));
+                        }
+                        Err(e) => return Err(e),
+                    },
                     _ => return json_err!(InvalidEscape, index),
                 }
                 index += 1;
+            } else if allow_partial {
+                // input ends right after the backslash, keep the span before it
+                return Ok((start..index - 1, index));
             } else {
                 return json_err!(EofWhileParsingString, index);
             }

--- a/crates/jiter/tests/main.rs
+++ b/crates/jiter/tests/main.rs
@@ -1693,6 +1693,29 @@ fn jiter_partial_string_escape() {
 }
 
 #[test]
+fn jiter_partial_bytes_escape() {
+    // next_bytes should agree with next_str when the input is truncated inside an escape
+    for data in [
+        br#"["foo\"#.as_slice(),
+        br#"["foo\u"#.as_slice(),
+        br#"["foo\u1"#.as_slice(),
+        br#"["foo\u12"#.as_slice(),
+        br#"["foo\u123"#.as_slice(),
+    ] {
+        let mut str_jiter = Jiter::new(data).with_allow_partial_strings();
+        assert_eq!(str_jiter.next_array().unwrap(), Some(Peek::String));
+        let s = str_jiter.next_str().unwrap();
+
+        let mut bytes_jiter = Jiter::new(data).with_allow_partial_strings();
+        assert_eq!(bytes_jiter.next_array().unwrap(), Some(Peek::String));
+        let b = bytes_jiter.next_bytes().unwrap();
+
+        assert_eq!(b, s.as_bytes(), "data: {:?}", String::from_utf8_lossy(data));
+        assert_eq!(b, b"foo", "data: {:?}", String::from_utf8_lossy(data));
+    }
+}
+
+#[test]
 fn test_unicode_roundtrip() {
     // '"中文"'
     let json_bytes = b"\"\\u4e2d\\u6587\"";


### PR DESCRIPTION
Fixes #272.

`next_bytes` goes through `StringDecoderRange`, which never checked `allow_partial` when the input ended inside an escape. So a stream cut right after a backslash, or in the middle of a `\u` escape, returned `EofWhileParsingString` while `next_str` returned the string parsed so far. #208 already made the tape path keep the value before the incomplete escape, this does the same in the range decoder so the two accessors agree.

Added a test that runs the truncated-escape inputs through both `next_str` and `next_bytes` and checks they line up.