### PR TITLE
x86_64 SIMD string scanning and int decoding

### DIFF
--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -274,10 +274,10 @@ impl IntParse {
 
         #[cfg(feature = "num-bigint")]
         {
-            #[cfg(target_arch = "aarch64")]
-            // in aarch64 we use a 128 bit registers - 16 bytes
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+            // with simd we use 128 bit registers - 16 bytes
             const ONGOING_CHUNK_MULTIPLIER: u64 = 10u64.pow(16);
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
             // decode_int_chunk_fallback - we parse 18 bytes when the number is ongoing
             const ONGOING_CHUNK_MULTIPLIER: u64 = 10u64.pow(18);
 

--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -274,12 +274,7 @@ impl IntParse {
 
         #[cfg(feature = "num-bigint")]
         {
-            #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-            // with simd we use 128 bit registers - 16 bytes
-            const ONGOING_CHUNK_MULTIPLIER: u64 = 10u64.pow(16);
-            #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-            // decode_int_chunk_fallback - we parse 18 bytes when the number is ongoing
-            const ONGOING_CHUNK_MULTIPLIER: u64 = 10u64.pow(18);
+            use crate::simd::ONGOING_CHUNK_MULTIPLIER;
 
             const POW_10: [u64; 18] = [
                 10u64.pow(0),

--- a/crates/jiter/src/simd/mod.rs
+++ b/crates/jiter/src/simd/mod.rs
@@ -15,6 +15,12 @@ pub(crate) use x86_64::decode_string_chunk;
 
 use crate::number_decoder::IntChunk;
 
+/// the number of digits consumed per `IntChunk::Ongoing` chunk from `decode_int_chunk_big`
+#[cfg(all(feature = "num-bigint", any(target_arch = "aarch64", target_arch = "x86_64")))]
+pub(crate) const ONGOING_CHUNK_MULTIPLIER: u64 = 10u64.pow(16);
+#[cfg(all(feature = "num-bigint", not(any(target_arch = "aarch64", target_arch = "x86_64"))))]
+pub(crate) const ONGOING_CHUNK_MULTIPLIER: u64 = 10u64.pow(18);
+
 #[inline(always)]
 pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usize) {
     #[cfg(target_arch = "aarch64")]

--- a/crates/jiter/src/simd/mod.rs
+++ b/crates/jiter/src/simd/mod.rs
@@ -2,12 +2,16 @@
 mod aarch64;
 mod fallback_int;
 mod fallback_string;
+#[cfg(target_arch = "x86_64")]
+mod x86_64;
 
 #[cfg(target_arch = "aarch64")]
 pub(crate) use aarch64::decode_string_chunk;
 pub(crate) use fallback_int::decode_int_chunk as decode_int_chunk_small;
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
 pub(crate) use fallback_string::decode_string_chunk;
+#[cfg(target_arch = "x86_64")]
+pub(crate) use x86_64::decode_string_chunk;
 
 use crate::number_decoder::IntChunk;
 
@@ -18,7 +22,11 @@ pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usiz
         // SAFETY: all supported aarch64 targets support neon intrinsics
         unsafe { aarch64::decode_int_chunk_big(data, index) }
     }
-    #[cfg(not(target_arch = "aarch64"))]
+    #[cfg(target_arch = "x86_64")]
+    {
+        x86_64::decode_int_chunk_big(data, index)
+    }
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
     {
         fallback_int::decode_int_chunk(data, index, 0)
     }

--- a/crates/jiter/src/simd/mod.rs
+++ b/crates/jiter/src/simd/mod.rs
@@ -5,21 +5,39 @@ mod fallback_string;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
-#[cfg(target_arch = "aarch64")]
-pub(crate) use aarch64::decode_string_chunk;
 pub(crate) use fallback_int::decode_int_chunk as decode_int_chunk_small;
-#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-pub(crate) use fallback_string::decode_string_chunk;
-#[cfg(target_arch = "x86_64")]
-pub(crate) use x86_64::decode_string_chunk;
 
+use crate::errors::JsonResult;
 use crate::number_decoder::IntChunk;
+use crate::string_decoder::StringChunk;
 
 /// the number of digits consumed per `IntChunk::Ongoing` chunk from `decode_int_chunk_big`
 #[cfg(all(feature = "num-bigint", any(target_arch = "aarch64", target_arch = "x86_64")))]
 pub(crate) const ONGOING_CHUNK_MULTIPLIER: u64 = 10u64.pow(16);
 #[cfg(all(feature = "num-bigint", not(any(target_arch = "aarch64", target_arch = "x86_64"))))]
 pub(crate) const ONGOING_CHUNK_MULTIPLIER: u64 = 10u64.pow(18);
+
+#[inline(always)]
+pub(crate) fn decode_string_chunk(
+    data: &[u8],
+    index: usize,
+    ascii_only: bool,
+    allow_partial: bool,
+) -> JsonResult<(StringChunk, bool, usize)> {
+    #[cfg(target_arch = "aarch64")]
+    {
+        aarch64::decode_string_chunk(data, index, ascii_only, allow_partial)
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SAFETY: SSE2 is part of the x86_64 baseline.
+        unsafe { x86_64::decode_string_chunk(data, index, ascii_only, allow_partial) }
+    }
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    {
+        fallback_string::decode_string_chunk(data, index, ascii_only, allow_partial)
+    }
+}
 
 #[inline(always)]
 pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usize) {
@@ -30,7 +48,8 @@ pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usiz
     }
     #[cfg(target_arch = "x86_64")]
     {
-        x86_64::decode_int_chunk_big(data, index)
+        // SAFETY: SSE2 is part of the x86_64 baseline.
+        unsafe { x86_64::decode_int_chunk_big(data, index) }
     }
     #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
     {

--- a/crates/jiter/src/simd/x86_64.rs
+++ b/crates/jiter/src/simd/x86_64.rs
@@ -1,0 +1,214 @@
+use std::mem::transmute;
+#[rustfmt::skip]
+use std::arch::x86_64::{
+    __m128i,
+    _mm_loadu_si128 as simd_load_16,
+    _mm_cmpeq_epi8 as simd_eq_16,
+    _mm_cmplt_epi8 as simd_lt_signed_16,
+    _mm_min_epu8 as simd_min_16,
+    _mm_or_si128 as simd_or_16,
+    _mm_movemask_epi8 as simd_movemask_16,
+    _mm_sub_epi8 as simd_sub_16,
+    _mm_slli_si128 as simd_shift_bytes_16,
+    _mm_and_si128 as simd_and_16,
+    _mm_srli_epi16 as simd_shift_right_u16_8,
+    _mm_mullo_epi16 as simd_mul_u16_8,
+    _mm_add_epi16 as simd_add_u16_8,
+    _mm_madd_epi16 as simd_mul_add_u16_8,
+    _mm_mul_epu32 as simd_mul_u32_4,
+    _mm_srli_epi64 as simd_shift_right_u64_2,
+    _mm_add_epi64 as simd_add_u64_2,
+};
+use crate::errors::{JsonResult, json_err};
+
+use crate::number_decoder::IntChunk;
+use crate::string_decoder::StringChunk;
+
+use super::fallback_int::decode_int_chunk;
+use super::fallback_string::{CHAR_TYPE, CharType, JSON_ASCII};
+
+type SimdVec = __m128i;
+const SIMD_STEP: usize = 16;
+
+macro_rules! simd_const {
+    ($array:expr) => {
+        unsafe { transmute($array) }
+    };
+}
+
+const ZERO_DIGIT_16: SimdVec = simd_const!([b'0'; 16]);
+const NINE_VAL_16: SimdVec = simd_const!([9u8; 16]);
+const LOW_BYTE_U16_8: SimdVec = simd_const!([0x00ffu16; 8]);
+const TEN_U16_8: SimdVec = simd_const!([10u16; 8]);
+const ALT_MUL_U16_8: SimdVec = simd_const!([100u16, 1u16, 100u16, 1u16, 100u16, 1u16, 100u16, 1u16]);
+const ALT_MUL_U32_4: SimdVec = simd_const!([10000u32, 0u32, 10000u32, 0u32]);
+
+#[inline(always)]
+pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usize) {
+    if let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
+        let byte_vec = load_slice(byte_chunk);
+        let digits = unsafe { simd_sub_16(byte_vec, ZERO_DIGIT_16) };
+
+        let last_digit = first_non_digit(digits);
+        if last_digit == 16 {
+            let value = unsafe { full_calc(digits, 16) };
+            (IntChunk::Ongoing(value), index + SIMD_STEP)
+        } else {
+            let index = index + last_digit as usize;
+            if next_is_float(data, index) {
+                (IntChunk::Float, index)
+            } else {
+                let value = unsafe { full_calc(digits, last_digit) };
+                (IntChunk::Done(value), index)
+            }
+        }
+    } else {
+        decode_int_chunk(data, index, 0)
+    }
+}
+
+/// position of the first byte that is not a digit, 16 if all bytes are digits
+fn first_non_digit(digits: SimdVec) -> u32 {
+    unsafe {
+        let digit_mask = simd_eq_16(simd_min_16(digits, NINE_VAL_16), digits);
+        (!mask_to_u32(digit_mask)).trailing_zeros()
+    }
+}
+
+// TODO: SSSE3 `_mm_maddubs_epi16` would replace the and/shift/mullo/add byte->u16 step
+// TODO: SSE4.1 `_mm_packus_epi32` could pair lanes and shorten the u32->u64 reduction
+unsafe fn full_calc(digits: SimdVec, last_digit: u32) -> u64 {
+    unsafe {
+        let digits = match last_digit {
+            0 => return 0,
+            1 => simd_shift_bytes_16::<15>(digits),
+            2 => simd_shift_bytes_16::<14>(digits),
+            3 => simd_shift_bytes_16::<13>(digits),
+            4 => simd_shift_bytes_16::<12>(digits),
+            5 => simd_shift_bytes_16::<11>(digits),
+            6 => simd_shift_bytes_16::<10>(digits),
+            7 => simd_shift_bytes_16::<9>(digits),
+            8 => simd_shift_bytes_16::<8>(digits),
+            9 => simd_shift_bytes_16::<7>(digits),
+            10 => simd_shift_bytes_16::<6>(digits),
+            11 => simd_shift_bytes_16::<5>(digits),
+            12 => simd_shift_bytes_16::<4>(digits),
+            13 => simd_shift_bytes_16::<3>(digits),
+            14 => simd_shift_bytes_16::<2>(digits),
+            15 => simd_shift_bytes_16::<1>(digits),
+            16 => digits,
+            _ => unreachable!("last_digit should be at most 16"),
+        };
+        // 16x8-bit lanes -> 8x16-bit lanes: first digit * 10 + second digit
+        let lo = simd_and_16(digits, LOW_BYTE_U16_8);
+        let hi = simd_shift_right_u16_8::<8>(digits);
+        let x = simd_add_u16_8(simd_mul_u16_8(lo, TEN_U16_8), hi);
+        // 8x16-bit lanes -> 4x32-bit lanes: first * 100 + second
+        let x = simd_mul_add_u16_8(x, ALT_MUL_U16_8);
+        // 4x32-bit lanes -> 2x64-bit lanes: first * 10000 + second
+        let x = simd_add_u64_2(simd_mul_u32_4(x, ALT_MUL_U32_4), simd_shift_right_u64_2::<32>(x));
+
+        let t: [u64; 2] = transmute(x);
+        t[0].wrapping_mul(100_000_000).wrapping_add(t[1])
+    }
+}
+
+fn next_is_float(data: &[u8], index: usize) -> bool {
+    let next = unsafe { data.get_unchecked(index) };
+    matches!(next, b'.' | b'e' | b'E')
+}
+
+const QUOTE_16: SimdVec = simd_const!([b'"'; 16]);
+const BACKSLASH_16: SimdVec = simd_const!([b'\\'; 16]);
+const CONTROL_16: SimdVec = simd_const!([32u8; 16]);
+const CONTROL_MAX_16: SimdVec = simd_const!([31u8; 16]);
+
+// TODO: an AVX2 32-byte loop behind `is_x86_feature_detected!` may help long strings
+#[inline(always)]
+pub(crate) fn decode_string_chunk(
+    data: &[u8],
+    mut index: usize,
+    mut ascii_only: bool,
+    allow_partial: bool,
+) -> JsonResult<(StringChunk, bool, usize)> {
+    while let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
+        let byte_vec = load_slice(byte_chunk);
+
+        if mask_to_u32(string_ascii_mask(byte_vec)) != 0 {
+            // this chunk contains a special character, classify the first one with a scalar scan.
+            // this looks like it defeats the point of SIMD, but the byte-by-byte scan branches
+            // are predictable and crucially keep the returned index off the (slow) vector->general
+            // register transfer path, unlike computing the position from the mask
+            for (pos, next) in byte_chunk.iter().enumerate() {
+                if !JSON_ASCII[*next as usize] {
+                    match &CHAR_TYPE[*next as usize] {
+                        CharType::Quote => return Ok((StringChunk::StringEnd, ascii_only, index + pos)),
+                        CharType::Backslash => return Ok((StringChunk::Backslash, ascii_only, index + pos)),
+                        CharType::ControlChar => return json_err!(ControlCharacterWhileParsingString, index + pos),
+                        CharType::Other => {
+                            // non-ascii character: use the mask to jump over the rest of the
+                            // chunk instead of scanning it byte-by-byte
+                            ascii_only = false;
+                            let stop_mask = mask_to_u32(string_stop_mask(byte_vec));
+                            if stop_mask != 0 {
+                                let stop_pos = stop_mask.trailing_zeros() as usize;
+                                index += stop_pos;
+                                return match byte_chunk[stop_pos] {
+                                    b'"' => Ok((StringChunk::StringEnd, false, index)),
+                                    b'\\' => Ok((StringChunk::Backslash, false, index)),
+                                    _ => json_err!(ControlCharacterWhileParsingString, index),
+                                };
+                            }
+                            // no stop character in this chunk, continue to the next chunk
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        index += SIMD_STEP;
+    }
+    // we got near the end of the string, fall back to the slow path
+    super::fallback_string::decode_string_chunk(data, index, ascii_only, allow_partial)
+}
+
+#[rustfmt::skip]
+/// returns a mask where any non-zero byte means we don't have a simple ascii character, either
+/// quote, backslash, control character, or non-ascii (above 127). The signed comparison against
+/// 32 catches both control characters and bytes above 127, which are negative as i8
+fn string_ascii_mask(byte_vec: SimdVec) -> SimdVec {
+    unsafe {
+        simd_or_16(
+            simd_eq_16(byte_vec, QUOTE_16),
+            simd_or_16(
+                simd_eq_16(byte_vec, BACKSLASH_16),
+                simd_lt_signed_16(byte_vec, CONTROL_16),
+            )
+        )
+    }
+}
+
+#[rustfmt::skip]
+/// returns a mask where any non-zero byte is a character that stops the string scan: either
+/// a quote, backslash, or control character
+fn string_stop_mask(byte_vec: SimdVec) -> SimdVec {
+    unsafe {
+        simd_or_16(
+            simd_eq_16(byte_vec, QUOTE_16),
+            simd_or_16(
+                simd_eq_16(byte_vec, BACKSLASH_16),
+                simd_eq_16(simd_min_16(byte_vec, CONTROL_MAX_16), byte_vec),
+            )
+        )
+    }
+}
+
+/// one bit per byte lane, set where the comparison mask lane is 0xFF
+fn mask_to_u32(mask: SimdVec) -> u32 {
+    unsafe { simd_movemask_16(mask).cast_unsigned() }
+}
+
+fn load_slice(bytes: &[u8]) -> SimdVec {
+    debug_assert_eq!(bytes.len(), 16);
+    unsafe { simd_load_16(bytes.as_ptr().cast()) }
+}

--- a/crates/jiter/src/simd/x86_64.rs
+++ b/crates/jiter/src/simd/x86_64.rs
@@ -43,11 +43,12 @@ const TEN_U16_8: SimdVec = simd_const!([10u16; 8]);
 const ALT_MUL_U16_8: SimdVec = simd_const!([100u16, 1u16, 100u16, 1u16, 100u16, 1u16, 100u16, 1u16]);
 const ALT_MUL_U32_4: SimdVec = simd_const!([10000u32, 0u32, 10000u32, 0u32]);
 
-#[inline(always)]
+#[inline]
+#[target_feature(enable = "sse2")]
 pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usize) {
     if let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
         let byte_vec = load_slice(byte_chunk);
-        let digits = unsafe { simd_sub_16(byte_vec, ZERO_DIGIT_16) };
+        let digits = simd_sub_16(byte_vec, ZERO_DIGIT_16);
 
         let last_digit = first_non_digit(digits);
         if last_digit == 16 {
@@ -68,15 +69,15 @@ pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usiz
 }
 
 /// position of the first byte that is not a digit, 16 if all bytes are digits
+#[target_feature(enable = "sse2")]
 fn first_non_digit(digits: SimdVec) -> u32 {
-    unsafe {
-        let digit_mask = simd_eq_16(simd_min_16(digits, NINE_VAL_16), digits);
-        (!mask_to_u32(digit_mask)).trailing_zeros()
-    }
+    let digit_mask = simd_eq_16(simd_min_16(digits, NINE_VAL_16), digits);
+    (!mask_to_u32(digit_mask)).trailing_zeros()
 }
 
 // TODO: SSSE3 `_mm_maddubs_epi16` would replace the and/shift/mullo/add byte->u16 step
 // TODO: SSE4.1 `_mm_packus_epi32` could pair lanes and shorten the u32->u64 reduction
+#[target_feature(enable = "sse2")]
 unsafe fn full_calc(digits: SimdVec, last_digit: u32) -> u64 {
     unsafe {
         let digits = match last_digit {
@@ -124,7 +125,8 @@ const CONTROL_16: SimdVec = simd_const!([32u8; 16]);
 const CONTROL_MAX_16: SimdVec = simd_const!([31u8; 16]);
 
 // TODO: an AVX2 32-byte loop behind `is_x86_feature_detected!` may help long strings
-#[inline(always)]
+#[inline]
+#[target_feature(enable = "sse2")]
 pub(crate) fn decode_string_chunk(
     data: &[u8],
     mut index: usize,
@@ -176,38 +178,38 @@ pub(crate) fn decode_string_chunk(
 /// returns a mask where any non-zero byte means we don't have a simple ascii character, either
 /// quote, backslash, control character, or non-ascii (above 127). The signed comparison against
 /// 32 catches both control characters and bytes above 127, which are negative as i8
+#[target_feature(enable = "sse2")]
 fn string_ascii_mask(byte_vec: SimdVec) -> SimdVec {
-    unsafe {
+    simd_or_16(
+        simd_eq_16(byte_vec, QUOTE_16),
         simd_or_16(
-            simd_eq_16(byte_vec, QUOTE_16),
-            simd_or_16(
-                simd_eq_16(byte_vec, BACKSLASH_16),
-                simd_lt_signed_16(byte_vec, CONTROL_16),
-            )
+            simd_eq_16(byte_vec, BACKSLASH_16),
+            simd_lt_signed_16(byte_vec, CONTROL_16),
         )
-    }
+    )
 }
 
 #[rustfmt::skip]
 /// returns a mask where any non-zero byte is a character that stops the string scan: either
 /// a quote, backslash, or control character
+#[target_feature(enable = "sse2")]
 fn string_stop_mask(byte_vec: SimdVec) -> SimdVec {
-    unsafe {
+    simd_or_16(
+        simd_eq_16(byte_vec, QUOTE_16),
         simd_or_16(
-            simd_eq_16(byte_vec, QUOTE_16),
-            simd_or_16(
-                simd_eq_16(byte_vec, BACKSLASH_16),
-                simd_eq_16(simd_min_16(byte_vec, CONTROL_MAX_16), byte_vec),
-            )
+            simd_eq_16(byte_vec, BACKSLASH_16),
+            simd_eq_16(simd_min_16(byte_vec, CONTROL_MAX_16), byte_vec),
         )
-    }
+    )
 }
 
 /// one bit per byte lane, set where the comparison mask lane is 0xFF
+#[target_feature(enable = "sse2")]
 fn mask_to_u32(mask: SimdVec) -> u32 {
-    unsafe { simd_movemask_16(mask).cast_unsigned() }
+    simd_movemask_16(mask).cast_unsigned()
 }
 
+#[target_feature(enable = "sse2")]
 fn load_slice(bytes: &[u8]) -> SimdVec {
     debug_assert_eq!(bytes.len(), 16);
     unsafe { simd_load_16(bytes.as_ptr().cast()) }


### PR DESCRIPTION
Port the aarch64 NEON fast paths (`decode_string_chunk`, `decode_int_chunk_big`) to x86_64 using SSE2 only, selected at compile time with `cfg(target_arch = "x86_64")` — no runtime feature detection, since SSE2 is in the x86_64 baseline.

## Design

- **String scan** keeps the aarch64 shape (#270): the mask only detects a special chunk and jumps over non-ascii runs; the stop character is found by the scalar table scan so the returned index stays off the vector→GPR path. `pmovmskb` gives a bit-per-byte mask so no `vshrn` nibble trick. A single signed `pcmpgtb` against 32 catches control chars *and* bytes ≥ 0x80 (negative as i8).
- **Int decoding** right-aligns digits with `pslldq` and reduces via `pmullw`/`paddw` → `pmaddwd` → `pmuludq`. One `full_calc` covers 0..=16 digits.
- `ONGOING_CHUNK_MULTIPLIER` in `number_decoder.rs` is now `10^16` on both SIMD arches.
- One-line `TODO`s mark follow-ups: SSSE3 `pmaddubsw`, SSE4.1 lane packing, AVX2 32-byte loop.

## Verification

- Ran the full test suite for `x86_64-apple-darwin` under Rosetta (incl. serde proptest) plus native aarch64 — all green. This caught one bug during development (all-digit mask → `trailing_zeros` of 0).
- clippy `-D warnings` on x86_64 and the wasm32 fallback, `cargo bench -- --test` on x86_64.
- `objdump` of the x86 release build shows `pmovmskb`/`pmaddwd`/`pmuludq`/`pslldq` and no `cpuid`.

## Not yet measured

CodSpeed's macro runners are arm64, so the bench job here only confirms aarch64 is unchanged. x86 performance numbers still need a `cargo bench` main-vs-branch run on real x86 hardware (e.g. a Codespace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvr4FioDLzkHkriM5to3wC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the aarch64 NEON fast paths for string scanning and integer decoding to x86_64 via SSE2 intrinsics, gated with `#[target_feature(enable = "sse2")]` and selected at compile time with `cfg(target_arch = "x86_64")`. No runtime feature detection is needed because SSE2 is part of the x86_64 baseline.

- String scanning uses a `pmovmskb` bit-per-byte mask to jump over non-ASCII runs; the stop character is still located by the scalar scan so the index stays off the vector→GPR path.
- Integer decoding right-aligns digits with `pslldq` and reduces via `pmullw`/`paddw`, `pmaddwd`, and `pmuludq`; one `full_calc` covers 0..=16 digits.
- `ONGOING_CHUNK_MULTIPLIER` moved into `simd/mod.rs` and is now `10^16` for both SIMD architectures; `number_decoder.rs` imports it.
- SIMD intrinsic calls sit behind the dispatchers in `simd/mod.rs` and are wrapped in `unsafe` blocks.
- `TODO`s mark follow-ups for SSSE3, SSE4.1, and AVX2.

**Verification**
- Full test suite passes on x86_64 (under Rosetta) and aarch64; clippy with `-D warnings` passes on x86_64 and wasm32 fallback.
- `cargo bench -- --test` passes on x86_64, but x86 benchmark numbers on real hardware are still pending (CodSpeed runners are arm64).

<sup>Written for commit 4fd4265b3b3a76fdd229e663fbd59911d11bd3c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

