### PR TITLE
Python optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ debug = true
 [workspace.dependencies]
 pyo3 = { version = "0.29.2" }
 pyo3-build-config = { version = "0.29.2" }
+
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/crates/jiter-python/bench.py
+++ b/crates/jiter-python/bench.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import math
 import timeit
 from pathlib import Path
 
@@ -86,6 +87,7 @@ def main():
 
     parsers = [*PARSERS.keys()] if 'all' in args.parsers else args.parsers
     cases = [*CASES.keys()] if args.case == 'all' else [args.case]
+    slowdowns: dict[str, list[float]] = {parser: [] for parser in parsers}
 
     for name in cases:
         print(f'Case: {name}')
@@ -103,7 +105,30 @@ def main():
         print(f'{"-" * 13}|{"-" * 12}|{"-" * 9}')
         for name, time in times:
             print(f'{name:>12} | {time * 1_000_000:10.2f} | {time / best:8.2f}')
+            slowdowns[name].append(time / best)
         print()
+
+    if len(cases) > 1:
+        print_summary(slowdowns)
+
+
+def print_summary(slowdowns: dict[str, list[float]]) -> None:
+    rows = []
+    for parser, ratios in slowdowns.items():
+        geomean = math.exp(sum(map(math.log, ratios)) / len(ratios))
+        rows.append((parser, geomean, max(ratios), sum(r == 1 for r in ratios)))
+    rows.sort(key=lambda r: r[1])
+    best = rows[0][1]
+
+    print('Summary (slowdown relative to the fastest package in each case):')
+    print(
+        f'{"rank":>4} | {"package":>12} | {"geomean":>8} | {"vs best":>8} | {"worst":>8} | {"wins":>4}'
+    )
+    print(f'{"-" * 5}|{"-" * 14}|{"-" * 10}|{"-" * 10}|{"-" * 10}|{"-" * 5}')
+    for rank, (parser, geomean, worst, wins) in enumerate(rows, start=1):
+        print(
+            f'{rank:>4} | {parser:>12} | {geomean:8.2f} | {geomean / best:8.2f} | {worst:8.2f} | {wins:>4}'
+        )
 
 
 if __name__ == '__main__':

--- a/crates/jiter-python/bench.py
+++ b/crates/jiter-python/bench.py
@@ -22,9 +22,7 @@ for p in BENCHES_DIR.glob('*.json'):
     CASES[p.stem] = p.read_bytes()
 
 
-def run_bench(func, d, fast: bool):
-    if isinstance(d, str):
-        d = d.encode()
+def run_bench(func, d: bytes, fast: bool):
     timer = timeit.Timer(
         'func(json_data)', setup='', globals={'func': func, 'json_data': d}
     )
@@ -93,19 +91,26 @@ def main():
         print(f'Case: {name}')
 
         json_data = CASES[name]
-        times = [
-            (parser, run_bench(PARSERS[parser](), json_data, args.fast))
-            for parser in parsers
-        ]
+        if isinstance(json_data, str):
+            json_data = json_data.encode()
+        expected = json.loads(json_data)
+        times = []
+        for parser in parsers:
+            func = PARSERS[parser]()
+            valid = func(json_data) == expected
+            times.append((parser, run_bench(func, json_data, args.fast), valid))
 
-        times.sort(key=lambda x: x[1])
+        times.sort(key=lambda x: (not x[2], x[1]))
         best = times[0][1]
 
         print(f'{"package":>12} | {"time µs":>10} | slowdown')
         print(f'{"-" * 13}|{"-" * 12}|{"-" * 9}')
-        for name, time in times:
-            print(f'{name:>12} | {time * 1_000_000:10.2f} | {time / best:8.2f}')
-            slowdowns[name].append(time / best)
+        for name, time, valid in times:
+            if valid:
+                print(f'{name:>12} | {time * 1_000_000:10.2f} | {time / best:8.2f}')
+                slowdowns[name].append(time / best)
+            else:
+                print(f'{name:>12} | {time * 1_000_000:10.2f} | {"invalid":>8}')
         print()
 
     if len(cases) > 1:
@@ -120,7 +125,10 @@ def print_summary(slowdowns: dict[str, list[float]]) -> None:
     rows.sort(key=lambda r: r[1])
     best = rows[0][1]
 
-    print('Summary (slowdown relative to the fastest package in each case):')
+    print(
+        'Summary (slowdown relative to the fastest package in each case, '
+        'excluding cases where the package returned the wrong result):'
+    )
     print(
         f'{"rank":>4} | {"package":>12} | {"geomean":>8} | {"vs best":>8} | {"worst":>8} | {"wins":>4}'
     )

--- a/crates/jiter-python/bench.py
+++ b/crates/jiter-python/bench.py
@@ -97,16 +97,22 @@ def main():
         times = []
         for parser in parsers:
             func = PARSERS[parser]()
-            valid = func(json_data) == expected
+            try:
+                valid = func(json_data) == expected
+            except Exception:  # noqa: BLE001
+                times.append((parser, None, False))
+                continue
             times.append((parser, run_bench(func, json_data, args.fast), valid))
 
-        times.sort(key=lambda x: (not x[2], x[1]))
+        times.sort(key=lambda x: (not x[2], x[1] or math.inf))
         best = times[0][1]
 
         print(f'{"package":>12} | {"time µs":>10} | slowdown')
         print(f'{"-" * 13}|{"-" * 12}|{"-" * 9}')
         for name, time, valid in times:
-            if valid:
+            if time is None:
+                print(f'{name:>12} | {"-":>10} | {"error":>8}')
+            elif valid:
                 print(f'{name:>12} | {time * 1_000_000:10.2f} | {time / best:8.2f}')
                 slowdowns[name].append(time / best)
             else:
@@ -120,6 +126,9 @@ def main():
 def print_summary(slowdowns: dict[str, list[float]]) -> None:
     rows = []
     for parser, ratios in slowdowns.items():
+        if not ratios:
+            print(f'{parser}: no valid results, excluded from summary')
+            continue
         geomean = math.exp(sum(map(math.log, ratios)) / len(ratios))
         rows.append((parser, geomean, max(ratios), sum(r == 1 for r in ratios)))
     rows.sort(key=lambda r: r[1])

--- a/crates/jiter-python/tests/test_jiter.py
+++ b/crates/jiter-python/tests/test_jiter.py
@@ -1,3 +1,4 @@
+import gc
 import json
 import sys
 from concurrent.futures import ThreadPoolExecutor
@@ -413,3 +414,31 @@ def test_multithreaded_parsing():
 
         for result in results:
             assert result.result()
+
+
+def test_cache_clear_during_parse_does_not_deadlock():
+    # on CPython <= 3.11 a GC can run inside the parser's allocations, on newer versions it's deferred
+    # to the eval loop, so this only exercises the re-entrancy check on older versions
+    unraisable = []
+    gc_calls = []
+
+    def callback(phase, info):
+        gc_calls.append(phase)
+        jiter.cache_clear()
+
+    data = ('[' + ','.join('{"key": "value"}' for _ in range(50_000)) + ']').encode()
+    thresholds = gc.get_threshold()
+    gc.callbacks.append(callback)
+    hook = sys.unraisablehook
+    sys.unraisablehook = unraisable.append
+    try:
+        gc.set_threshold(1)
+        result = jiter.from_json(data, cache_mode=True)
+    finally:
+        sys.unraisablehook = hook
+        gc.callbacks.remove(callback)
+        gc.set_threshold(*thresholds)
+
+    assert len(result) == 50_000
+    for u in unraisable:
+        assert 'locked by a parse in progress' in str(u.exc_value)

--- a/crates/jiter/src/py_string_cache.rs
+++ b/crates/jiter/src/py_string_cache.rs
@@ -331,6 +331,9 @@ pub unsafe fn pystring_ascii_new<'py>(py: Python<'py>, s: &str) -> Bound<'py, Py
     unsafe {
         #[cfg(not(any(PyPy, GraalPy, Py_LIMITED_API)))]
         {
+            if s.len() == 1 {
+                return PyString::new(py, s);
+            }
             // SAFETY: `PyUnicode_New` returns a new owned reference or null. Converting it to a
             // `Bound` immediately ensures an allocation failure is handled before dereferencing it.
             let py_string = Bound::from_owned_ptr(py, pyo3::ffi::PyUnicode_New(s.len() as isize, 127));

--- a/crates/jiter/src/py_string_cache.rs
+++ b/crates/jiter/src/py_string_cache.rs
@@ -1,4 +1,4 @@
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::{Mutex, MutexGuard, OnceLock, TryLockError};
 
 use ahash::random_state::RandomState;
 use pyo3::exceptions::{PyTypeError, PyValueError};
@@ -44,32 +44,85 @@ impl From<bool> for StringCacheMode {
     }
 }
 
-pub trait StringMaybeCache {
-    fn get_key<'py>(py: Python<'py>, string_output: StringOutput<'_, '_>) -> Bound<'py, PyString>;
+pub type StringCacheGuard = Option<MutexGuard<'static, PyStringCache>>;
 
-    fn get_value<'py>(py: Python<'py>, string_output: StringOutput<'_, '_>) -> Bound<'py, PyString> {
-        Self::get_key(py, string_output)
+pub trait StringMaybeCache {
+    fn acquire() -> StringCacheGuard {
+        None
+    }
+
+    fn get_key<'py>(
+        py: Python<'py>,
+        guard: &mut StringCacheGuard,
+        string_output: StringOutput<'_, '_>,
+    ) -> Bound<'py, PyString>;
+
+    fn get_value<'py>(
+        py: Python<'py>,
+        guard: &mut StringCacheGuard,
+        string_output: StringOutput<'_, '_>,
+    ) -> Bound<'py, PyString> {
+        Self::get_key(py, guard, string_output)
+    }
+}
+
+/// # Safety
+///
+/// Caller must match the ascii_only flag to the string passed in.
+#[inline]
+unsafe fn guarded_py_string<'py>(
+    py: Python<'py>,
+    guard: &mut StringCacheGuard,
+    string_output: &StringOutput<'_, '_>,
+) -> Bound<'py, PyString> {
+    let s = string_output.as_str();
+    let ascii_only = string_output.ascii_only();
+    unsafe {
+        match guard {
+            Some(cache) if (2..64).contains(&s.len()) => cache.get_or_insert(py, s, ascii_only),
+            _ => pystring_fast_new_maybe_ascii(py, s, ascii_only),
+        }
     }
 }
 
 pub struct StringCacheAll;
 
 impl StringMaybeCache for StringCacheAll {
-    fn get_key<'py>(py: Python<'py>, string_output: StringOutput<'_, '_>) -> Bound<'py, PyString> {
+    fn acquire() -> StringCacheGuard {
+        try_get_string_cache()
+    }
+
+    fn get_key<'py>(
+        py: Python<'py>,
+        guard: &mut StringCacheGuard,
+        string_output: StringOutput<'_, '_>,
+    ) -> Bound<'py, PyString> {
         // SAFETY: `StringOutput` guarantees that its ASCII flag matches its contents.
-        unsafe { cached_py_string_maybe_ascii(py, string_output.as_str(), string_output.ascii_only()) }
+        unsafe { guarded_py_string(py, guard, &string_output) }
     }
 }
 
 pub struct StringCacheKeys;
 
 impl StringMaybeCache for StringCacheKeys {
-    fn get_key<'py>(py: Python<'py>, string_output: StringOutput<'_, '_>) -> Bound<'py, PyString> {
-        // SAFETY: `StringOutput` guarantees that its ASCII flag matches its contents.
-        unsafe { cached_py_string_maybe_ascii(py, string_output.as_str(), string_output.ascii_only()) }
+    fn acquire() -> StringCacheGuard {
+        try_get_string_cache()
     }
 
-    fn get_value<'py>(py: Python<'py>, string_output: StringOutput<'_, '_>) -> Bound<'py, PyString> {
+    fn get_key<'py>(
+        py: Python<'py>,
+        guard: &mut StringCacheGuard,
+        string_output: StringOutput<'_, '_>,
+    ) -> Bound<'py, PyString> {
+        // SAFETY: `StringOutput` guarantees that its ASCII flag matches its contents.
+        unsafe { guarded_py_string(py, guard, &string_output) }
+    }
+
+    fn get_value<'py>(
+        py: Python<'py>,
+        _guard: &mut StringCacheGuard,
+        string_output: StringOutput<'_, '_>,
+    ) -> Bound<'py, PyString> {
         // SAFETY: `StringOutput` guarantees that its ASCII flag matches its contents.
         unsafe { pystring_fast_new_maybe_ascii(py, string_output.as_str(), string_output.ascii_only()) }
     }
@@ -78,7 +131,11 @@ impl StringMaybeCache for StringCacheKeys {
 pub struct StringNoCache;
 
 impl StringMaybeCache for StringNoCache {
-    fn get_key<'py>(py: Python<'py>, string_output: StringOutput<'_, '_>) -> Bound<'py, PyString> {
+    fn get_key<'py>(
+        py: Python<'py>,
+        _guard: &mut StringCacheGuard,
+        string_output: StringOutput<'_, '_>,
+    ) -> Bound<'py, PyString> {
         // SAFETY: `StringOutput` guarantees that its ASCII flag matches its contents.
         unsafe { pystring_fast_new_maybe_ascii(py, string_output.as_str(), string_output.ascii_only()) }
     }
@@ -96,6 +153,22 @@ fn get_string_cache() -> MutexGuard<'static, PyStringCache> {
             cache.clear();
             cache
         }
+    }
+}
+
+#[inline]
+fn try_get_string_cache() -> StringCacheGuard {
+    match STRING_CACHE
+        .get_or_init(|| Mutex::new(PyStringCache::default()))
+        .try_lock()
+    {
+        Ok(cache) => Some(cache),
+        Err(TryLockError::Poisoned(poisoned)) => {
+            let mut cache = poisoned.into_inner();
+            cache.clear();
+            Some(cache)
+        }
+        Err(TryLockError::WouldBlock) => None,
     }
 }
 
@@ -148,7 +221,7 @@ type Entry = Option<(u64, Py<PyString>)>;
 /// This is a Fully associative cache with LRU replacement policy.
 /// See https://en.wikipedia.org/wiki/Cache_placement_policies#Fully_associative_cache
 #[derive(Debug)]
-struct PyStringCache {
+pub struct PyStringCache {
     entries: Box<[Entry; CAPACITY]>,
     hash_builder: RandomState,
 }

--- a/crates/jiter/src/py_string_cache.rs
+++ b/crates/jiter/src/py_string_cache.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::sync::{Mutex, MutexGuard, OnceLock, TryLockError};
 
 use ahash::random_state::RandomState;
@@ -44,11 +45,24 @@ impl From<bool> for StringCacheMode {
     }
 }
 
-pub type StringCacheGuard = Option<MutexGuard<'static, PyStringCache>>;
+thread_local! {
+    static CACHE_HELD_BY_THIS_THREAD: Cell<bool> = const { Cell::new(false) };
+}
+
+#[derive(Default)]
+pub struct StringCacheGuard(Option<MutexGuard<'static, PyStringCache>>);
+
+impl Drop for StringCacheGuard {
+    fn drop(&mut self) {
+        if self.0.is_some() {
+            CACHE_HELD_BY_THIS_THREAD.set(false);
+        }
+    }
+}
 
 pub trait StringMaybeCache {
     fn acquire() -> StringCacheGuard {
-        None
+        StringCacheGuard::default()
     }
 
     fn get_key<'py>(
@@ -78,7 +92,7 @@ unsafe fn guarded_py_string<'py>(
     let s = string_output.as_str();
     let ascii_only = string_output.ascii_only();
     unsafe {
-        match guard {
+        match &mut guard.0 {
             Some(cache) if (2..64).contains(&s.len()) => cache.get_or_insert(py, s, ascii_only),
             _ => pystring_fast_new_maybe_ascii(py, s, ascii_only),
         }
@@ -145,6 +159,10 @@ static STRING_CACHE: OnceLock<Mutex<PyStringCache>> = OnceLock::new();
 
 #[inline]
 fn get_string_cache() -> MutexGuard<'static, PyStringCache> {
+    assert!(
+        !CACHE_HELD_BY_THIS_THREAD.get(),
+        "jiter's string cache is locked by a parse in progress on this thread"
+    );
     match STRING_CACHE.get_or_init(|| Mutex::new(PyStringCache::default())).lock() {
         Ok(cache) => cache,
         Err(poisoned) => {
@@ -158,18 +176,20 @@ fn get_string_cache() -> MutexGuard<'static, PyStringCache> {
 
 #[inline]
 fn try_get_string_cache() -> StringCacheGuard {
-    match STRING_CACHE
+    let cache = match STRING_CACHE
         .get_or_init(|| Mutex::new(PyStringCache::default()))
         .try_lock()
     {
-        Ok(cache) => Some(cache),
+        Ok(cache) => cache,
         Err(TryLockError::Poisoned(poisoned)) => {
             let mut cache = poisoned.into_inner();
             cache.clear();
-            Some(cache)
+            cache
         }
-        Err(TryLockError::WouldBlock) => None,
-    }
+        Err(TryLockError::WouldBlock) => return StringCacheGuard(None),
+    };
+    CACHE_HELD_BY_THIS_THREAD.set(true);
+    StringCacheGuard(Some(cache))
 }
 
 pub fn cache_usage() -> usize {

--- a/crates/jiter/src/python.rs
+++ b/crates/jiter/src/python.rs
@@ -12,7 +12,9 @@ use crate::errors::{DEFAULT_RECURSION_LIMIT, JsonError, JsonResult, json_err, js
 use crate::number_decoder::{AbstractNumberDecoder, NumberAny, NumberRange};
 use crate::parse::{Parser, Peek};
 use crate::py_lossless_float::{FloatMode, get_decimal_type};
-use crate::py_string_cache::{StringCacheAll, StringCacheKeys, StringCacheMode, StringMaybeCache, StringNoCache};
+use crate::py_string_cache::{
+    StringCacheAll, StringCacheGuard, StringCacheKeys, StringCacheMode, StringMaybeCache, StringNoCache,
+};
 use crate::string_decoder::{StringDecoder, Tape};
 use crate::{JsonErrorType, LosslessFloat, PartialMode};
 
@@ -87,6 +89,7 @@ struct PythonParser<'j, StringCache, KeyCheck, ParseNumber> {
     _parse_number: PhantomData<ParseNumber>,
     parser: Parser<'j>,
     tape: Tape,
+    string_cache: StringCacheGuard,
     recursion_limit: u8,
     allow_inf_nan: bool,
     partial_mode: PartialMode,
@@ -107,6 +110,7 @@ impl<StringCache: StringMaybeCache, KeyCheck: MaybeKeyCheck, ParseNumber: MaybeP
             _parse_number: PhantomData::<ParseNumber>,
             parser: Parser::new(json_data),
             tape: Tape::default(),
+            string_cache: StringCache::acquire(),
             recursion_limit: DEFAULT_RECURSION_LIMIT,
             allow_inf_nan,
             partial_mode,
@@ -138,7 +142,7 @@ impl<StringCache: StringMaybeCache, KeyCheck: MaybeKeyCheck, ParseNumber: MaybeP
                 let s = self
                     .parser
                     .consume_string::<StringDecoder>(&mut self.tape, self.partial_mode.allow_trailing_str())?;
-                Ok(StringCache::get_value(py, s).into_any())
+                Ok(StringCache::get_value(py, &mut self.string_cache, s).into_any())
             }
             Peek::Array => {
                 let peek_first = match self.parser.array_first() {
@@ -200,14 +204,14 @@ impl<StringCache: StringMaybeCache, KeyCheck: MaybeKeyCheck, ParseNumber: MaybeP
         if let Some(first_key) = self.parser.object_first::<StringDecoder>(&mut self.tape)? {
             let first_key_s = first_key.as_str();
             check_keys.check(first_key_s, self.parser.index)?;
-            let first_key = StringCache::get_key(py, first_key);
+            let first_key = StringCache::get_key(py, &mut self.string_cache, first_key);
             let peek = self.parser.peek()?;
             let first_value = self.check_take_value(py, peek)?;
             set_item(first_key, first_value);
             while let Some(key) = self.parser.object_step::<StringDecoder>(&mut self.tape)? {
                 let key_s = key.as_str();
                 check_keys.check(key_s, self.parser.index)?;
-                let key = StringCache::get_key(py, key);
+                let key = StringCache::get_key(py, &mut self.string_cache, key);
                 let peek = self.parser.peek()?;
                 let value = self.check_take_value(py, peek)?;
                 set_item(key, value);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Speeds up Python parsing by locking the string cache once per parse instead of per string, and enables the same release optimizations for wheel builds that the Rust benchmarks already had.

Also makes the Python benchmark script more correct: it now validates each parser's output against `json.loads` and shows a cross-case summary.

- The cache lock is acquired with `try_lock`, so concurrent parses fall back to uncached strings instead of blocking on the mutex.
- Re-entering the cache from a parse on the same thread panics with a clear message instead of deadlocking; other threads still block.
- Single-character ASCII strings use CPython's interned singletons, avoiding allocation for each short string.
- `profile.release` now uses `lto = "fat"` and `codegen-units = 1` for compiled wheels.
- Benchmark rows that don't match stdlib output are shown as invalid and excluded from the summary; parsers that raise are shown as errors and not timed.

<sup>Written for commit fc620f449c00c5cf7c7ea8f193199473798cacb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

