### PR TITLE
Benchmark script summary and validation, LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ debug = true
 [workspace.dependencies]
 pyo3 = { version = "0.29.2" }
 pyo3-build-config = { version = "0.29.2" }
+
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/crates/jiter-python/bench.py
+++ b/crates/jiter-python/bench.py
@@ -98,11 +98,12 @@ def main():
         for parser in parsers:
             func = PARSERS[parser]()
             try:
+                time = run_bench(func, json_data, args.fast)
                 valid = json.dumps(func(json_data)) == expected
             except Exception:  # noqa: BLE001
                 times.append((parser, None, False))
                 continue
-            times.append((parser, run_bench(func, json_data, args.fast), valid))
+            times.append((parser, time, valid))
 
         times.sort(key=lambda x: (not x[2], x[1] or math.inf))
         best = times[0][1]
@@ -131,6 +132,8 @@ def print_summary(slowdowns: dict[str, list[float]]) -> None:
             continue
         geomean = math.exp(sum(map(math.log, ratios)) / len(ratios))
         rows.append((parser, geomean, max(ratios), sum(r == 1 for r in ratios)))
+    if not rows:
+        return
     rows.sort(key=lambda r: r[1])
     best = rows[0][1]
 

--- a/crates/jiter-python/bench.py
+++ b/crates/jiter-python/bench.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import math
 import timeit
 from pathlib import Path
 
@@ -86,6 +87,7 @@ def main():
 
     parsers = [*PARSERS.keys()] if 'all' in args.parsers else args.parsers
     cases = [*CASES.keys()] if args.case == 'all' else [args.case]
+    slowdowns: dict[str, list[float]] = {parser: [] for parser in parsers}
 
     for name in cases:
         print(f'Case: {name}')
@@ -103,7 +105,30 @@ def main():
         print(f'{"-" * 13}|{"-" * 12}|{"-" * 9}')
         for name, time in times:
             print(f'{name:>12} | {time * 1_000_000:10.2f} | {time / best:8.2f}')
+            slowdowns[name].append(time / best)
         print()
+
+    if len(cases) > 1:
+        print_summary(slowdowns)
+
+
+def print_summary(slowdowns: dict[str, list[float]]) -> None:
+    rows = []
+    for parser, ratios in slowdowns.items():
+        geomean = math.exp(sum(map(math.log, ratios)) / len(ratios))
+        rows.append((parser, geomean, max(ratios), sum(r == 1 for r in ratios)))
+    rows.sort(key=lambda r: r[1])
+    best = rows[0][1]
+
+    print('Summary (slowdown relative to the fastest package in each case):')
+    print(
+        f'{"rank":>4} | {"package":>12} | {"geomean":>8} | {"vs best":>8} | {"worst":>8} | {"wins":>4}'
+    )
+    print(f'{"-" * 5}|{"-" * 14}|{"-" * 10}|{"-" * 10}|{"-" * 10}|{"-" * 5}')
+    for rank, (parser, geomean, worst, wins) in enumerate(rows, start=1):
+        print(
+            f'{rank:>4} | {parser:>12} | {geomean:8.2f} | {geomean / best:8.2f} | {worst:8.2f} | {wins:>4}'
+        )
 
 
 if __name__ == '__main__':

--- a/crates/jiter-python/bench.py
+++ b/crates/jiter-python/bench.py
@@ -93,12 +93,12 @@ def main():
         json_data = CASES[name]
         if isinstance(json_data, str):
             json_data = json_data.encode()
-        expected = json.loads(json_data)
+        expected = json.dumps(json.loads(json_data))
         times = []
         for parser in parsers:
             func = PARSERS[parser]()
             try:
-                valid = func(json_data) == expected
+                valid = json.dumps(func(json_data)) == expected
             except Exception:  # noqa: BLE001
                 times.append((parser, None, False))
                 continue

--- a/crates/jiter-python/bench.py
+++ b/crates/jiter-python/bench.py
@@ -22,9 +22,7 @@ for p in BENCHES_DIR.glob('*.json'):
     CASES[p.stem] = p.read_bytes()
 
 
-def run_bench(func, d, fast: bool):
-    if isinstance(d, str):
-        d = d.encode()
+def run_bench(func, d: bytes, fast: bool):
     timer = timeit.Timer(
         'func(json_data)', setup='', globals={'func': func, 'json_data': d}
     )
@@ -93,19 +91,26 @@ def main():
         print(f'Case: {name}')
 
         json_data = CASES[name]
-        times = [
-            (parser, run_bench(PARSERS[parser](), json_data, args.fast))
-            for parser in parsers
-        ]
+        if isinstance(json_data, str):
+            json_data = json_data.encode()
+        expected = json.loads(json_data)
+        times = []
+        for parser in parsers:
+            func = PARSERS[parser]()
+            valid = func(json_data) == expected
+            times.append((parser, run_bench(func, json_data, args.fast), valid))
 
-        times.sort(key=lambda x: x[1])
+        times.sort(key=lambda x: (not x[2], x[1]))
         best = times[0][1]
 
         print(f'{"package":>12} | {"time µs":>10} | slowdown')
         print(f'{"-" * 13}|{"-" * 12}|{"-" * 9}')
-        for name, time in times:
-            print(f'{name:>12} | {time * 1_000_000:10.2f} | {time / best:8.2f}')
-            slowdowns[name].append(time / best)
+        for name, time, valid in times:
+            if valid:
+                print(f'{name:>12} | {time * 1_000_000:10.2f} | {time / best:8.2f}')
+                slowdowns[name].append(time / best)
+            else:
+                print(f'{name:>12} | {time * 1_000_000:10.2f} | {"invalid":>8}')
         print()
 
     if len(cases) > 1:
@@ -120,7 +125,10 @@ def print_summary(slowdowns: dict[str, list[float]]) -> None:
     rows.sort(key=lambda r: r[1])
     best = rows[0][1]
 
-    print('Summary (slowdown relative to the fastest package in each case):')
+    print(
+        'Summary (slowdown relative to the fastest package in each case, '
+        'excluding cases where the package returned the wrong result):'
+    )
     print(
         f'{"rank":>4} | {"package":>12} | {"geomean":>8} | {"vs best":>8} | {"worst":>8} | {"wins":>4}'
     )

--- a/crates/jiter-python/bench.py
+++ b/crates/jiter-python/bench.py
@@ -97,16 +97,22 @@ def main():
         times = []
         for parser in parsers:
             func = PARSERS[parser]()
-            valid = func(json_data) == expected
+            try:
+                valid = func(json_data) == expected
+            except Exception:  # noqa: BLE001
+                times.append((parser, None, False))
+                continue
             times.append((parser, run_bench(func, json_data, args.fast), valid))
 
-        times.sort(key=lambda x: (not x[2], x[1]))
+        times.sort(key=lambda x: (not x[2], x[1] or math.inf))
         best = times[0][1]
 
         print(f'{"package":>12} | {"time µs":>10} | slowdown')
         print(f'{"-" * 13}|{"-" * 12}|{"-" * 9}')
         for name, time, valid in times:
-            if valid:
+            if time is None:
+                print(f'{name:>12} | {"-":>10} | {"error":>8}')
+            elif valid:
                 print(f'{name:>12} | {time * 1_000_000:10.2f} | {time / best:8.2f}')
                 slowdowns[name].append(time / best)
             else:
@@ -120,6 +126,9 @@ def main():
 def print_summary(slowdowns: dict[str, list[float]]) -> None:
     rows = []
     for parser, ratios in slowdowns.items():
+        if not ratios:
+            print(f'{parser}: no valid results, excluded from summary')
+            continue
         geomean = math.exp(sum(map(math.log, ratios)) / len(ratios))
         rows.append((parser, geomean, max(ratios), sum(r == 1 for r in ratios)))
     rows.sort(key=lambda r: r[1])


### PR DESCRIPTION
Split out of #280 so the uncontroversial parts can merge on their own.

`crates/jiter-python/bench.py`:
- each parser's output is checked against `json.loads`; mismatches are shown as `invalid`, excluded from the per-case baseline and from the summary. orjson returns lossy floats for `massive_ints_array`, so its lead there was never like-for-like
- a parser that raises on a case is shown as `error` and not timed, instead of aborting the run
- a summary table at the end ranks packages by the geometric mean of their per-case slowdown, with worst case and number of wins

`Cargo.toml`: `[profile.release]` gets `lto = "fat"` and `codegen-units = 1`. `maturin develop --release` and the CI wheel builds use this profile, which had neither setting (only `profile.bench` did). Profiles are only honoured at the workspace root; `crates/fuzz` is its own workspace and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011axe7edsWuf1JqHQS88Npo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Python benchmark script's reliability by validating parser output and tolerating parser errors, and enables LTO for release builds.

**Benchmark script**
- Parser output is checked against `json.loads` via canonical `json.dumps` serialization after timing (validating first would warm jiter's string cache and skew `--fast` runs); mismatches show as `invalid` and are excluded from the summary, which removes orjson's inflated lead on `massive_ints_array` due to lossy floats.
- Parsers that raise on a case show as `error` and are skipped instead of aborting the run.
- A summary table for multi-case runs ranks packages by geometric mean slowdown, with worst case and win count per package; it's skipped when no parser has valid results.

**Release builds**
- `profile.release` now sets `lto = "fat"` and `codegen-units = 1`, so `maturin develop --release` and CI wheel builds get the same optimizations as `profile.bench`.
- `crates/fuzz` is its own workspace and remains unaffected.

<sup>Written for commit a58440e5617a293d8b3c28d7e82723af98536cd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

