### PR TITLE
Disable ASLR for the CodSpeed bench run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,8 @@ jobs:
 
       - uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
-          # ASLR shifts the memory layout per process, moving small benches ~5-10% between runs, see https://github.com/pydantic/jiter/pull/283
+          # ASLR shifts the memory layout per process, moving small benches ~5-10% between runs,
+          # see https://github.com/pydantic/jiter/pull/284
           run: setarch $(uname -m) -R cargo codspeed run
           mode: walltime
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,8 @@ jobs:
 
       - uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
-          run: cargo codspeed run
+          # ASLR shifts the memory layout per process, moving small benches ~5-10% between runs, see https://github.com/pydantic/jiter/pull/283
+          run: setarch $(uname -m) -R cargo codspeed run
           mode: walltime
           token: ${{ secrets.CODSPEED_TOKEN }}
 


### PR DESCRIPTION
Wraps `cargo codspeed run` in `setarch $(uname -m) -R`, as suggested in https://github.com/pydantic/jiter/pull/283#issuecomment-5469640062.

The small benches (`true_array`, `short_numbers`, `string_array`, ...) were moving 5-10% between runs with identical trees; the bot traced it to per-process ASLR picking one of two stable memory layouts. With randomisation off, 15 processes of one binary spread by ~0.3% instead of ~5%.

Layout still depends on argv/env, and `GITHUB_REF` differs between PR and main runs, so this should remove most of the flapping rather than all of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuRFMkJQuCS6zDrFYydFMr

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables ASLR for the CodSpeed bench run so small benchmarks stop swinging 5-10% between otherwise identical runs. Wraps `cargo codspeed run` in `setarch $(uname -m) -R`, and the measured spread across 15 processes drops to ~0.3%.

Memory layout still depends on argv/env, and `GITHUB_REF` differs between PR and main runs, so most of the flapping is removed rather than all.

<sup>Written for commit 4cc166aec1ed7f963266c039f8dd377a1f18bf43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

