### PR TITLE
Scalar prefix scan before the SIMD string loop

### DIFF
--- a/crates/jiter/src/simd/mod.rs
+++ b/crates/jiter/src/simd/mod.rs
@@ -3,13 +3,45 @@ mod aarch64;
 mod fallback_int;
 mod fallback_string;
 
-#[cfg(target_arch = "aarch64")]
-pub(crate) use aarch64::decode_string_chunk;
 pub(crate) use fallback_int::decode_int_chunk as decode_int_chunk_small;
-#[cfg(not(target_arch = "aarch64"))]
-pub(crate) use fallback_string::decode_string_chunk;
 
+use crate::errors::{JsonResult, json_err};
 use crate::number_decoder::IntChunk;
+use crate::string_decoder::StringChunk;
+use fallback_string::{CHAR_TYPE, CharType, JSON_ASCII};
+
+/// bytes scanned byte-by-byte before entering the SIMD loop
+const SCALAR_PREFIX: usize = 8;
+
+#[inline(always)]
+pub(crate) fn decode_string_chunk(
+    data: &[u8],
+    mut index: usize,
+    mut ascii_only: bool,
+    allow_partial: bool,
+) -> JsonResult<(StringChunk, bool, usize)> {
+    let prefix_end = data.len().min(index + SCALAR_PREFIX);
+    while index < prefix_end {
+        let next = data[index];
+        if !JSON_ASCII[next as usize] {
+            match &CHAR_TYPE[next as usize] {
+                CharType::Quote => return Ok((StringChunk::StringEnd, ascii_only, index)),
+                CharType::Backslash => return Ok((StringChunk::Backslash, ascii_only, index)),
+                CharType::ControlChar => return json_err!(ControlCharacterWhileParsingString, index),
+                CharType::Other => ascii_only = false,
+            }
+        }
+        index += 1;
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        aarch64::decode_string_chunk(data, index, ascii_only, allow_partial)
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        fallback_string::decode_string_chunk(data, index, ascii_only, allow_partial)
+    }
+}
 
 #[inline(always)]
 pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usize) {


### PR DESCRIPTION
`decode_string_chunk` is re-entered after every escape, and object keys and short strings end within a few bytes,
so the SIMD loop's 16-byte load, compares and mask extraction are usually spent classifying a byte the scalar
`JSON_ASCII` lookup finds immediately.
Benchmarking the SSE2 port (#279) on a GCE c3 machine put the cost against the scalar fallback at
`json_cases_escapes_jiter_value` +34%, `string_array_jiter_value` +6% and `true_object_jiter_value` +4.9%.
The aarch64 code has the same structure, so the same overhead is expected there; the json-cases corpus benchmarks
postdate the aarch64 SIMD, so it was never measured.

This scans up to 8 bytes with the existing scalar tables before dispatching to the per-arch SIMD loop.
Strings longer than the prefix take the SIMD path from byte 8 as before.

Expected on CodSpeed:

- escape-dense and short-string benches (`json_cases_escapes`, `true_object`, `string_array_jiter_value`) should improve
- long-string benches (`x100`, `sentence`, `unicode_dense`) are the canary: they now pay up to 8 scalar iterations
  per string before the first vector load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wd8Ccx5ah8FVyjRiKycf6i