### PR TITLE
use digit run to determine float or integer decode

### DIFF
--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -11,7 +11,7 @@ use lexical_parse_float::{FromLexicalWithOptions, Options as ParseFloatOptions, 
 
 use crate::{
     errors::{JsonError, JsonResult, json_err, json_error},
-    simd::{decode_int_chunk_big, decode_int_chunk_small, find_digit_run_end},
+    simd::{decode_int_chunk_big, decode_int_chunk_small, decode_number_prefix, find_digit_run_end},
 };
 
 pub trait AbstractNumberDecoder: Sized {
@@ -182,45 +182,82 @@ impl AbstractNumberDecoder for NumberAny {
         }
 
         let digit_start = index;
-        match if positive { Some(&first) } else { data.get(index) } {
+        let int_prefix = match if positive { Some(&first) } else { data.get(index) } {
             Some(b'I') => {
                 return consume_inf_f64(data, index, positive, allow_inf_nan)
                     .map(|(float, end)| (Self::Float(float), end));
             }
             Some(b'0') => {
-                let end = find_digit_run_end(data, digit_start);
-                if end != digit_start + 1 {
-                    return json_err!(InvalidNumber, digit_start + 1);
+                index += 1;
+                match data.get(index) {
+                    Some(digit) if digit.is_ascii_digit() => return json_err!(InvalidNumber, index),
+                    Some(b'.' | b'e' | b'E') => None,
+                    _ => return Ok((Self::Int(NumberInt::Int(0)), index)),
                 }
-                index = end;
             }
-            Some(b'1'..=b'9') => index = find_digit_run_end(data, digit_start),
+            Some(b'1'..=b'9') => {
+                let (chunk, end) = decode_number_prefix(data, digit_start);
+                index = end;
+                match chunk {
+                    IntChunk::Done(value) => {
+                        return Ok((Self::Int(short_integer(value, positive)), index));
+                    }
+                    IntChunk::Float => None,
+                    IntChunk::Ongoing(value) => Some((value, end)),
+                }
+            }
             Some(_) => return json_err!(InvalidNumber, index),
             None => return json_err!(EofWhileParsingValue, index),
+        };
+
+        if let Some((prefix, prefix_end)) = int_prefix {
+            let limit = start.saturating_add(4300);
+            index =
+                find_digit_run_end(data, index, limit).ok_or_else(|| json_error!(NumberOutOfRange, start + 4301))?;
+            if !matches!(data.get(index), Some(b'.' | b'e' | b'E')) {
+                let int = decode_integer_digits(data, digit_start, index, positive, prefix, prefix_end)?;
+                return Ok((Self::Int(int), index));
+            }
         }
 
-        if matches!(data.get(index), Some(b'.' | b'e' | b'E')) {
-            parse_json_float(data, start, allow_inf_nan).map(|(float, end)| (Self::Float(float), end))
-        } else {
-            decode_integer_digits(data, start, digit_start, index, positive).map(|int| (Self::Int(int), index))
-        }
+        parse_json_float(data, start, allow_inf_nan).map(|(float, end)| (Self::Float(float), end))
     }
+}
+
+fn short_integer(magnitude: u64, positive: bool) -> NumberInt {
+    let value = if positive {
+        magnitude as i64
+    } else {
+        -(magnitude as i64)
+    };
+    NumberInt::Int(value)
 }
 
 fn decode_integer_digits(
     data: &[u8],
-    start: usize,
     digit_start: usize,
     end: usize,
     positive: bool,
+    prefix: u64,
+    prefix_end: usize,
 ) -> JsonResult<NumberInt> {
-    let digits = &data[digit_start..end];
-    if digits.len() <= 18 {
-        let magnitude = digits
-            .iter()
-            .fold(0u64, |value, digit| value * 10 + u64::from(digit & 0x0f));
+    let magnitude = if end - digit_start <= 19 {
+        Some(
+            data[prefix_end..end]
+                .iter()
+                .fold(prefix, |value, digit| value * 10 + u64::from(digit & 0x0f)),
+        )
+    } else {
+        None
+    };
+    let max_magnitude = if positive { i64::MAX as u64 } else { i64::MAX as u64 + 1 };
+    if let Some(magnitude) = magnitude
+        && magnitude <= max_magnitude
+    {
         let value = if positive {
             magnitude as i64
+        } else if magnitude == i64::MAX as u64 + 1 {
+            i64::MIN
         } else {
             -(magnitude as i64)
         };
@@ -229,22 +266,21 @@ fn decode_integer_digits(
 
     #[cfg(not(feature = "num-bigint"))]
     {
-        let _ = start;
         json_err!(NumberOutOfRange, digit_start + 1)
     }
 
     #[cfg(feature = "num-bigint")]
     {
-        if end - start > 4300 {
-            return json_err!(NumberOutOfRange, start + 4301);
-        }
-        let first_chunk_len = (digits.len() - 1) % 16 + 1;
-        let first_chunk_end = digit_start + first_chunk_len;
-        let first_chunk = data[digit_start..first_chunk_end]
-            .iter()
-            .fold(0u64, |value, digit| value * 10 + u64::from(digit & 0x0f));
-        let mut value = BigInt::from(first_chunk);
-        let mut index = first_chunk_end;
+        let (mut value, mut index) = if let Some(magnitude) = magnitude {
+            (BigInt::from(magnitude), end)
+        } else {
+            let first_chunk_len = (end - digit_start - 1) % 16 + 1;
+            let first_chunk_end = digit_start + first_chunk_len;
+            let first_chunk = data[digit_start..first_chunk_end]
+                .iter()
+                .fold(0u64, |value, digit| value * 10 + u64::from(digit & 0x0f));
+            (BigInt::from(first_chunk), first_chunk_end)
+        };
         while index < end {
             let (chunk, new_index) = decode_int_chunk_big(data, index);
             let chunk = match chunk {

--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -195,17 +195,19 @@ impl AbstractNumberDecoder for NumberAny {
                     _ => return Ok((Self::Int(NumberInt::Int(0)), index)),
                 }
             }
-            Some(b'1'..=b'9') => {
-                let (chunk, end) = decode_number_prefix(data, digit_start);
-                index = end;
-                match chunk {
-                    IntChunk::Done(value) => {
-                        return Ok((Self::Int(short_integer(value, positive)), index));
-                    }
-                    IntChunk::Float => None,
-                    IntChunk::Ongoing(value) => Some((value, end)),
+            Some(b'1'..=b'9') => match decode_number_prefix(data, digit_start) {
+                Some((IntChunk::Done(value), end)) => {
+                    return Ok((Self::Int(short_integer(value, positive)), end));
                 }
-            }
+                Some((IntChunk::Float, end)) => {
+                    index = end;
+                    None
+                }
+                Some((IntChunk::Ongoing(_), _)) => {
+                    unreachable!("four-digit prefixes are handled by the digit-run scanner")
+                }
+                None => Some((0, digit_start)),
+            },
             Some(_) => return json_err!(InvalidNumber, index),
             None => return json_err!(EofWhileParsingValue, index),
         };

--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -11,7 +11,7 @@ use lexical_parse_float::{FromLexicalWithOptions, Options as ParseFloatOptions, 
 
 use crate::{
     errors::{JsonError, JsonResult, json_err, json_error},
-    simd::{decode_int_chunk_big, decode_int_chunk_small},
+    simd::{decode_int_chunk_big, decode_int_chunk_small, find_digit_run_end},
 };
 
 pub trait AbstractNumberDecoder: Sized {
@@ -104,20 +104,10 @@ impl AbstractNumberDecoder for NumberFloat {
 
         if let Some(digit) = first2 {
             if INT_CHAR_MAP[*digit as usize] {
-                const JSON: u128 = lexical_format::JSON;
                 let options = ParseFloatOptions::new();
-                match f64::from_lexical_partial_with_options::<JSON>(&data[start..], &options) {
+                match f64::from_lexical_partial_with_options::<JSON_FMT>(&data[start..], &options) {
                     Ok((float, index)) => Ok((Self(float), index + start)),
-                    Err(_) => {
-                        // it's impossible to work out the right error from LexicalError here, so we parse again
-                        // with NumberRange and use that error
-                        match NumberRange::decode(data, start, first, allow_inf_nan) {
-                            Err(e) => Err(e),
-                            // NumberRange should always raise an error if `parse_partial_with_options`
-                            // except for Infinity and -Infinity, which are handled above
-                            Ok(_) => unreachable!("NumberRange should always return an error"),
-                        }
-                    }
+                    Err(_) => float_error(data, start, allow_inf_nan).map(|(float, index)| (Self(float), index)),
                 }
             } else if digit == &b'I' {
                 let (f, end) = consume_inf_f64(data, index, positive, allow_inf_nan)?;
@@ -128,6 +118,28 @@ impl AbstractNumberDecoder for NumberFloat {
         } else {
             json_err!(EofWhileParsingValue, index)
         }
+    }
+}
+
+const JSON_FMT: u128 = lexical_format::JSON;
+
+#[inline(always)]
+fn parse_json_float(data: &[u8], start: usize, allow_inf_nan: bool) -> JsonResult<(f64, usize)> {
+    let options = ParseFloatOptions::new();
+    if let Ok((float, index)) = f64::from_lexical_partial_with_options::<JSON_FMT>(&data[start..], &options) {
+        Ok((float, index + start))
+    } else {
+        float_error(data, start, allow_inf_nan)
+    }
+}
+
+#[cold]
+#[inline(never)]
+fn float_error(data: &[u8], start: usize, allow_inf_nan: bool) -> JsonResult<(f64, usize)> {
+    let first = data.get(start).expect("float data to start within string");
+    match NumberRange::decode(data, start, *first, allow_inf_nan) {
+        Err(e) => Err(e),
+        Ok(_) => unreachable!("NumberRange should return an error if lexical-parse-float did"),
     }
 }
 
@@ -156,19 +168,102 @@ impl NumberAny {
 }
 
 impl AbstractNumberDecoder for NumberAny {
-    fn decode(data: &[u8], index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
+    fn decode(data: &[u8], mut index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
         let start = index;
-        let (int_parse, index) = IntParse::parse(data, index, first)?;
-        match int_parse {
-            IntParse::Int(int) => Ok((Self::Int(int), index)),
-            IntParse::Float => {
-                NumberFloat::decode(data, start, first, allow_inf_nan).map(|(f, index)| (Self::Float(f.0), index))
+        let positive = match first {
+            b'N' => {
+                return consume_nan(data, index, allow_inf_nan).map(|(float, end)| (Self::Float(float), end));
             }
-            IntParse::FloatInf(positive) => {
-                consume_inf_f64(data, index, positive, allow_inf_nan).map(|(f, index)| (Self::Float(f), index))
-            }
-            IntParse::FloatNaN => consume_nan(data, index, allow_inf_nan).map(|(f, index)| (Self::Float(f), index)),
+            b'-' => false,
+            _ => true,
+        };
+        if !positive {
+            index += 1;
         }
+
+        let digit_start = index;
+        match if positive { Some(&first) } else { data.get(index) } {
+            Some(b'I') => {
+                return consume_inf_f64(data, index, positive, allow_inf_nan)
+                    .map(|(float, end)| (Self::Float(float), end));
+            }
+            Some(b'0') => {
+                let end = find_digit_run_end(data, digit_start);
+                if end != digit_start + 1 {
+                    return json_err!(InvalidNumber, digit_start + 1);
+                }
+                index = end;
+            }
+            Some(b'1'..=b'9') => index = find_digit_run_end(data, digit_start),
+            Some(_) => return json_err!(InvalidNumber, index),
+            None => return json_err!(EofWhileParsingValue, index),
+        }
+
+        if matches!(data.get(index), Some(b'.' | b'e' | b'E')) {
+            parse_json_float(data, start, allow_inf_nan).map(|(float, end)| (Self::Float(float), end))
+        } else {
+            decode_integer_digits(data, start, digit_start, index, positive).map(|int| (Self::Int(int), index))
+        }
+    }
+}
+
+fn decode_integer_digits(
+    data: &[u8],
+    start: usize,
+    digit_start: usize,
+    end: usize,
+    positive: bool,
+) -> JsonResult<NumberInt> {
+    let digits = &data[digit_start..end];
+    if digits.len() <= 18 {
+        let magnitude = digits
+            .iter()
+            .fold(0u64, |value, digit| value * 10 + u64::from(digit & 0x0f));
+        let value = if positive {
+            magnitude as i64
+        } else {
+            -(magnitude as i64)
+        };
+        return Ok(NumberInt::Int(value));
+    }
+
+    #[cfg(not(feature = "num-bigint"))]
+    {
+        let _ = start;
+        json_err!(NumberOutOfRange, digit_start + 1)
+    }
+
+    #[cfg(feature = "num-bigint")]
+    {
+        if end - start > 4300 {
+            return json_err!(NumberOutOfRange, start + 4301);
+        }
+        let first_chunk_len = (digits.len() - 1) % 16 + 1;
+        let first_chunk_end = digit_start + first_chunk_len;
+        let first_chunk = data[digit_start..first_chunk_end]
+            .iter()
+            .fold(0u64, |value, digit| value * 10 + u64::from(digit & 0x0f));
+        let mut value = BigInt::from(first_chunk);
+        let mut index = first_chunk_end;
+        while index < end {
+            let (chunk, new_index) = decode_int_chunk_big(data, index);
+            let chunk = match chunk {
+                IntChunk::Ongoing(value) | IntChunk::Done(value) => value,
+                IntChunk::Float => unreachable!("known integer digit run to contain a float marker"),
+            };
+            let chunk_len = new_index - index;
+            value *= match chunk_len {
+                16 => 10u64.pow(16),
+                18 => 10u64.pow(18),
+                _ => 10u64.pow(chunk_len as u32),
+            };
+            value += chunk;
+            index = new_index;
+        }
+        if !positive {
+            value = -value;
+        }
+        Ok(NumberInt::BigInt(value))
     }
 }
 
@@ -214,15 +309,13 @@ fn consume_nan(data: &[u8], index: usize, allow_inf_nan: bool) -> JsonResult<(f6
 pub(crate) enum IntParse {
     Int(NumberInt),
     Float,
-    FloatInf(bool),
-    FloatNaN,
 }
 
 impl IntParse {
     pub(crate) fn parse(data: &[u8], mut index: usize, first: u8) -> JsonResult<(Self, usize)> {
         let start = index;
         let positive = match first {
-            b'N' => return Ok((Self::FloatNaN, index)),
+            b'N' => return Ok((Self::Float, index)),
             b'-' => false,
             _ => true,
         };
@@ -241,7 +334,7 @@ impl IntParse {
                     _ => Ok((Self::Int(NumberInt::Int(0)), index)),
                 };
             }
-            Some(b'I') => return Ok((Self::FloatInf(positive), index)),
+            Some(b'I') => return Ok((Self::Float, index)),
             Some(digit) if (b'1'..=b'9').contains(digit) => (digit & 0x0f) as u64,
             Some(_) => return json_err!(InvalidNumber, index),
             None => return json_err!(EofWhileParsingValue, index),

--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -106,11 +106,7 @@ impl AbstractNumberDecoder for NumberFloat {
 
         if let Some(digit) = first2 {
             if INT_CHAR_MAP[*digit as usize] {
-                let options = ParseFloatOptions::new();
-                match f64::from_lexical_partial_with_options::<JSON>(&data[start..], &options) {
-                    Ok((float, index)) => Ok((Self(float), index + start)),
-                    Err(_) => float_error(data, start, first, allow_inf_nan).map(|(float, index)| (Self(float), index)),
-                }
+                parse_json_float(data, start, first, allow_inf_nan).map(|(float, end)| (Self(float), end))
             } else if digit == &b'I' {
                 let (f, end) = consume_inf_f64(data, index, positive, allow_inf_nan)?;
                 Ok((Self(f), end))

--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -87,7 +87,7 @@ impl NumberFloat {
 }
 
 impl AbstractNumberDecoder for NumberFloat {
-    fn decode(data: &[u8], mut index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
+    fn decode(data: &[u8], mut index: usize, mut first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
         let start = index;
 
         let positive = match first {
@@ -95,45 +95,43 @@ impl AbstractNumberDecoder for NumberFloat {
                 let (f, end) = consume_nan(data, index, allow_inf_nan)?;
                 return Ok((Self(f), end));
             }
-            b'-' => false,
+            b'-' => {
+                index += 1;
+                first = *data
+                    .get(index)
+                    .ok_or_else(|| json_error!(EofWhileParsingValue, index))?;
+                false
+            }
             _ => true,
         };
-        if !positive {
-            // we started with a minus sign, so the first digit is at index + 1
-            index += 1;
-        }
-        let first2 = if positive { Some(&first) } else { data.get(index) };
 
-        if let Some(digit) = first2 {
-            if INT_CHAR_MAP[*digit as usize] {
-                parse_json_float(data, start, first, allow_inf_nan).map(|(float, end)| (Self(float), end))
-            } else if digit == &b'I' {
+        match first {
+            b'0'..=b'9' => parse_json_float(data, start, allow_inf_nan).map(|(float, end)| (Self(float), end)),
+            b'I' => {
                 let (f, end) = consume_inf_f64(data, index, positive, allow_inf_nan)?;
                 Ok((Self(f), end))
-            } else {
-                json_err!(InvalidNumber, index)
             }
-        } else {
-            json_err!(EofWhileParsingValue, index)
+            _ => json_err!(InvalidNumber, index),
         }
     }
 }
 
 /// Parse a JSON float prefix, preserving jiter's error kinds and positions.
 #[inline(always)]
-fn parse_json_float(data: &[u8], start: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(f64, usize)> {
+fn parse_json_float(data: &[u8], start: usize, allow_inf_nan: bool) -> JsonResult<(f64, usize)> {
     let options = ParseFloatOptions::new();
     if let Ok((float, index)) = f64::from_lexical_partial_with_options::<JSON>(&data[start..], &options) {
         Ok((float, index + start))
     } else {
-        float_error(data, start, first, allow_inf_nan)
+        float_error(data, start, allow_inf_nan)
     }
 }
 
 /// Recover a precise JSON error when lexical cannot parse a float.
 #[cold]
 #[inline(never)]
-fn float_error(data: &[u8], start: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(f64, usize)> {
+fn float_error(data: &[u8], start: usize, allow_inf_nan: bool) -> JsonResult<(f64, usize)> {
+    let first = *data.get(start).expect("float_error called with empty slice");
     match NumberRange::decode(data, start, first, allow_inf_nan) {
         Err(e) => Err(e),
         Ok(_) => unreachable!("NumberRange should return an error if lexical-parse-float did"),
@@ -168,26 +166,29 @@ impl AbstractNumberDecoder for NumberAny {
     /// Decode short integers directly; otherwise locate the integer digit-run terminator before
     /// choosing integer conversion or lexical's public float parser. This avoids accumulating a
     /// speculative integer mantissa for longer floats while keeping short integers single-pass.
-    fn decode(data: &[u8], mut index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
+    fn decode(data: &[u8], mut index: usize, mut first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
         let start = index;
         let positive = match first {
             b'N' => {
                 return consume_nan(data, index, allow_inf_nan).map(|(float, end)| (Self::Float(float), end));
             }
-            b'-' => false,
+            b'-' => {
+                index += 1;
+                first = *data
+                    .get(index)
+                    .ok_or_else(|| json_error!(EofWhileParsingValue, index))?;
+                false
+            }
             _ => true,
         };
-        if !positive {
-            index += 1;
-        }
 
         let digit_start = index;
-        let int_prefix = match if positive { Some(&first) } else { data.get(index) } {
-            Some(b'I') => {
+        let int_prefix = match first {
+            b'I' => {
                 return consume_inf_f64(data, index, positive, allow_inf_nan)
                     .map(|(float, end)| (Self::Float(float), end));
             }
-            Some(b'0') => {
+            b'0' => {
                 index += 1;
                 match data.get(index) {
                     Some(digit) if digit.is_ascii_digit() => return json_err!(InvalidNumber, index),
@@ -195,7 +196,7 @@ impl AbstractNumberDecoder for NumberAny {
                     _ => return Ok((Self::Int(NumberInt::Int(0)), index)),
                 }
             }
-            Some(b'1'..=b'9') => match decode_number_prefix(data, digit_start) {
+            b'1'..=b'9' => match decode_number_prefix(data, digit_start) {
                 Some((IntChunk::Done(value), end)) => {
                     return Ok((Self::Int(short_integer(value, positive)), end));
                 }
@@ -208,8 +209,7 @@ impl AbstractNumberDecoder for NumberAny {
                 }
                 None => Some((0, digit_start)),
             },
-            Some(_) => return json_err!(InvalidNumber, index),
-            None => return json_err!(EofWhileParsingValue, index),
+            _ => return json_err!(InvalidNumber, index),
         };
 
         if let Some((prefix, prefix_end)) = int_prefix {
@@ -222,7 +222,7 @@ impl AbstractNumberDecoder for NumberAny {
             }
         }
 
-        parse_json_float(data, start, first, allow_inf_nan).map(|(float, end)| (Self::Float(float), end))
+        parse_json_float(data, start, allow_inf_nan).map(|(float, end)| (Self::Float(float), end))
     }
 }
 
@@ -341,20 +341,21 @@ fn consume_nan(data: &[u8], index: usize, allow_inf_nan: bool) -> JsonResult<(f6
 }
 
 impl NumberInt {
-    fn parse(data: &[u8], mut index: usize, first: u8) -> JsonResult<(Self, usize)> {
+    fn parse(data: &[u8], mut index: usize, mut first: u8) -> JsonResult<(Self, usize)> {
         let start = index;
         let positive = match first {
             b'N' => return json_err!(FloatExpectingInt, index),
-            b'-' => false,
+            b'-' => {
+                index += 1;
+                first = *data
+                    .get(index)
+                    .ok_or_else(|| json_error!(EofWhileParsingValue, index))?;
+                false
+            }
             _ => true,
         };
-        if !positive {
-            // we started with a minus sign, so the first digit is at index + 1
-            index += 1;
-        }
-        let first2 = if positive { Some(&first) } else { data.get(index) };
-        let first_value = match first2 {
-            Some(b'0') => {
+        let first_value = match first {
+            b'0' => {
                 index += 1;
                 return match data.get(index) {
                     Some(b'.') => json_err!(FloatExpectingInt, index),
@@ -363,10 +364,9 @@ impl NumberInt {
                     _ => Ok((NumberInt::Int(0), index)),
                 };
             }
-            Some(b'I') => return json_err!(FloatExpectingInt, index),
-            Some(digit) if (b'1'..=b'9').contains(digit) => (digit & 0x0f) as u64,
-            Some(_) => return json_err!(InvalidNumber, index),
-            None => return json_err!(EofWhileParsingValue, index),
+            b'I' => return json_err!(FloatExpectingInt, index),
+            digit @ b'1'..=b'9' => (digit & 0x0f) as u64,
+            _ => return json_err!(InvalidNumber, index),
         };
 
         index += 1;
@@ -503,7 +503,7 @@ impl NumberRange {
 }
 
 impl AbstractNumberDecoder for NumberRange {
-    fn decode(data: &[u8], mut index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
+    fn decode(data: &[u8], mut index: usize, mut first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
         let start = index;
 
         let positive = match first {
@@ -511,16 +511,18 @@ impl AbstractNumberDecoder for NumberRange {
                 let (_, end) = consume_nan(data, index, allow_inf_nan)?;
                 return Ok((Self::float(start..end), end));
             }
-            b'-' => false,
+            b'-' => {
+                index += 1;
+                first = *data
+                    .get(index)
+                    .ok_or_else(|| json_error!(EofWhileParsingValue, index))?;
+                false
+            }
             _ => true,
         };
-        if !positive {
-            // we started with a minus sign, so the first digit is at index + 1
-            index += 1;
-        }
 
-        match data.get(index) {
-            Some(b'0') => {
+        match first {
+            b'0' => {
                 // numbers start with zero must be floats, next char must be a dot
                 index += 1;
                 return match data.get(index) {
@@ -538,13 +540,12 @@ impl AbstractNumberDecoder for NumberRange {
                     _ => return Ok((Self::int(start..index), index)),
                 };
             }
-            Some(b'I') => {
+            b'I' => {
                 let end = consume_inf(data, index, positive, allow_inf_nan)?;
                 return Ok((Self::float(start..end), end));
             }
-            Some(digit) if (b'1'..=b'9').contains(digit) => (),
-            Some(_) => return json_err!(InvalidNumber, index),
-            None => return json_err!(EofWhileParsingValue, index),
+            b'1'..=b'9' => (),
+            _ => return json_err!(InvalidNumber, index),
         }
 
         index += 1;

--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -10,9 +10,11 @@ use std::ops::Range;
 use lexical_parse_float::{FromLexicalWithOptions, Options as ParseFloatOptions, format as lexical_format};
 
 use crate::{
+    JsonErrorType::FloatExpectingInt,
     errors::{JsonError, JsonResult, json_err, json_error},
     simd::{decode_int_chunk_big, decode_int_chunk_small, decode_number_prefix, find_digit_run_end},
 };
+use lexical_format::JSON;
 
 pub trait AbstractNumberDecoder: Sized {
     fn decode(data: &[u8], index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)>;
@@ -50,21 +52,21 @@ impl NumberInt {
     /// is empty, or contains trailing bytes.
     pub fn from_bytes(data: &[u8]) -> JsonResult<Self> {
         let first = *data.first().ok_or_else(|| json_error!(InvalidNumber, 0))?;
-        let (int_parse, index) = IntParse::parse(data, 0, first)?;
-        match int_parse {
-            IntParse::Int(int) if index == data.len() => Ok(int),
-            _ => json_err!(InvalidNumber, index),
+        match NumberInt::parse(data, 0, first) {
+            Ok((int, index)) if index == data.len() => Ok(int),
+            Ok((_, index))
+            | Err(JsonError {
+                error_type: FloatExpectingInt,
+                index,
+            }) => json_err!(InvalidNumber, index),
+            Err(other) => Err(other),
         }
     }
 }
 
 impl AbstractNumberDecoder for NumberInt {
     fn decode(data: &[u8], index: usize, first: u8, _allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
-        let (int_parse, index) = IntParse::parse(data, index, first)?;
-        match int_parse {
-            IntParse::Int(int) => Ok((int, index)),
-            _ => json_err!(FloatExpectingInt, index),
-        }
+        Self::parse(data, index, first)
     }
 }
 
@@ -105,9 +107,9 @@ impl AbstractNumberDecoder for NumberFloat {
         if let Some(digit) = first2 {
             if INT_CHAR_MAP[*digit as usize] {
                 let options = ParseFloatOptions::new();
-                match f64::from_lexical_partial_with_options::<JSON_FMT>(&data[start..], &options) {
+                match f64::from_lexical_partial_with_options::<JSON>(&data[start..], &options) {
                     Ok((float, index)) => Ok((Self(float), index + start)),
-                    Err(_) => float_error(data, start, allow_inf_nan).map(|(float, index)| (Self(float), index)),
+                    Err(_) => float_error(data, start, first, allow_inf_nan).map(|(float, index)| (Self(float), index)),
                 }
             } else if digit == &b'I' {
                 let (f, end) = consume_inf_f64(data, index, positive, allow_inf_nan)?;
@@ -121,23 +123,22 @@ impl AbstractNumberDecoder for NumberFloat {
     }
 }
 
-const JSON_FMT: u128 = lexical_format::JSON;
-
+/// Parse a JSON float prefix, preserving jiter's error kinds and positions.
 #[inline(always)]
-fn parse_json_float(data: &[u8], start: usize, allow_inf_nan: bool) -> JsonResult<(f64, usize)> {
+fn parse_json_float(data: &[u8], start: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(f64, usize)> {
     let options = ParseFloatOptions::new();
-    if let Ok((float, index)) = f64::from_lexical_partial_with_options::<JSON_FMT>(&data[start..], &options) {
+    if let Ok((float, index)) = f64::from_lexical_partial_with_options::<JSON>(&data[start..], &options) {
         Ok((float, index + start))
     } else {
-        float_error(data, start, allow_inf_nan)
+        float_error(data, start, first, allow_inf_nan)
     }
 }
 
+/// Recover a precise JSON error when lexical cannot parse a float.
 #[cold]
 #[inline(never)]
-fn float_error(data: &[u8], start: usize, allow_inf_nan: bool) -> JsonResult<(f64, usize)> {
-    let first = data.get(start).expect("float data to start within string");
-    match NumberRange::decode(data, start, *first, allow_inf_nan) {
+fn float_error(data: &[u8], start: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(f64, usize)> {
+    match NumberRange::decode(data, start, first, allow_inf_nan) {
         Err(e) => Err(e),
         Ok(_) => unreachable!("NumberRange should return an error if lexical-parse-float did"),
     }
@@ -168,6 +169,9 @@ impl NumberAny {
 }
 
 impl AbstractNumberDecoder for NumberAny {
+    /// Decode short integers directly; otherwise locate the integer digit-run terminator before
+    /// choosing integer conversion or lexical's public float parser. This avoids accumulating a
+    /// speculative integer mantissa for longer floats while keeping short integers single-pass.
     fn decode(data: &[u8], mut index: usize, first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
         let start = index;
         let positive = match first {
@@ -213,16 +217,16 @@ impl AbstractNumberDecoder for NumberAny {
         };
 
         if let Some((prefix, prefix_end)) = int_prefix {
-            let limit = start.saturating_add(4300);
-            index =
-                find_digit_run_end(data, index, limit).ok_or_else(|| json_error!(NumberOutOfRange, start + 4301))?;
+            let limit = digit_start.saturating_add(4300);
+            index = find_digit_run_end(data, index, limit)
+                .ok_or_else(|| json_error!(NumberOutOfRange, digit_start + 4301))?;
             if !matches!(data.get(index), Some(b'.' | b'e' | b'E')) {
                 let int = decode_integer_digits(data, digit_start, index, positive, prefix, prefix_end)?;
                 return Ok((Self::Int(int), index));
             }
         }
 
-        parse_json_float(data, start, allow_inf_nan).map(|(float, end)| (Self::Float(float), end))
+        parse_json_float(data, start, first, allow_inf_nan).map(|(float, end)| (Self::Float(float), end))
     }
 }
 
@@ -235,6 +239,7 @@ fn short_integer(magnitude: u64, positive: bool) -> NumberInt {
     NumberInt::Int(value)
 }
 
+/// Convert a validated decimal digit run, extending any already-decoded prefix and applying its sign.
 fn decode_integer_digits(
     data: &[u8],
     digit_start: usize,
@@ -285,16 +290,12 @@ fn decode_integer_digits(
         };
         while index < end {
             let (chunk, new_index) = decode_int_chunk_big(data, index);
-            let chunk = match chunk {
-                IntChunk::Ongoing(value) | IntChunk::Done(value) => value,
+            let (chunk, multiplier) = match chunk {
+                IntChunk::Ongoing(value) => (value, crate::simd::ONGOING_CHUNK_MULTIPLIER),
+                IntChunk::Done(value) => (value, 10u64.pow((new_index - index) as u32)),
                 IntChunk::Float => unreachable!("known integer digit run to contain a float marker"),
             };
-            let chunk_len = new_index - index;
-            value *= match chunk_len {
-                16 => 10u64.pow(16),
-                18 => 10u64.pow(18),
-                _ => 10u64.pow(chunk_len as u32),
-            };
+            value *= multiplier;
             value += chunk;
             index = new_index;
         }
@@ -343,17 +344,11 @@ fn consume_nan(data: &[u8], index: usize, allow_inf_nan: bool) -> JsonResult<(f6
     }
 }
 
-#[derive(Debug)]
-pub(crate) enum IntParse {
-    Int(NumberInt),
-    Float,
-}
-
-impl IntParse {
-    pub(crate) fn parse(data: &[u8], mut index: usize, first: u8) -> JsonResult<(Self, usize)> {
+impl NumberInt {
+    fn parse(data: &[u8], mut index: usize, first: u8) -> JsonResult<(Self, usize)> {
         let start = index;
         let positive = match first {
-            b'N' => return Ok((Self::Float, index)),
+            b'N' => return json_err!(FloatExpectingInt, index),
             b'-' => false,
             _ => true,
         };
@@ -366,13 +361,13 @@ impl IntParse {
             Some(b'0') => {
                 index += 1;
                 return match data.get(index) {
-                    Some(b'.') => Ok((Self::Float, index)),
-                    Some(b'e' | b'E') => Ok((Self::Float, index)),
+                    Some(b'.') => json_err!(FloatExpectingInt, index),
+                    Some(b'e' | b'E') => json_err!(FloatExpectingInt, index),
                     Some(digit) if digit.is_ascii_digit() => json_err!(InvalidNumber, index),
-                    _ => Ok((Self::Int(NumberInt::Int(0)), index)),
+                    _ => Ok((NumberInt::Int(0), index)),
                 };
             }
-            Some(b'I') => return Ok((Self::Float, index)),
+            Some(b'I') => return json_err!(FloatExpectingInt, index),
             Some(digit) if (b'1'..=b'9').contains(digit) => (digit & 0x0f) as u64,
             Some(_) => return json_err!(InvalidNumber, index),
             None => return json_err!(EofWhileParsingValue, index),
@@ -388,9 +383,9 @@ impl IntParse {
                 if !positive {
                     value_i64 = -value_i64;
                 }
-                return Ok((Self::Int(NumberInt::Int(value_i64)), new_index));
+                return Ok((NumberInt::Int(value_i64), new_index));
             }
-            IntChunk::Float => return Ok((Self::Float, new_index)),
+            IntChunk::Float => return json_err!(FloatExpectingInt, new_index),
         };
 
         // number is too big for i64, we need to use a BigInt,
@@ -431,10 +426,11 @@ impl IntParse {
             let mut big_value: BigInt = ongoing.into();
             index = new_index;
 
+            let digit_start = start + usize::from(!positive);
             loop {
                 let (chunk, new_index) = decode_int_chunk_big(data, index);
-                if (new_index - start) > 4300 {
-                    return json_err!(NumberOutOfRange, start + 4301);
+                if (new_index - digit_start) > 4300 {
+                    return json_err!(NumberOutOfRange, digit_start + 4301);
                 }
                 match chunk {
                     IntChunk::Ongoing(value) => {
@@ -448,9 +444,9 @@ impl IntParse {
                         if !positive {
                             big_value = -big_value;
                         }
-                        return Ok((Self::Int(NumberInt::BigInt(big_value)), new_index));
+                        return Ok((NumberInt::BigInt(big_value), new_index));
                     }
-                    IntChunk::Float => return Ok((Self::Float, new_index)),
+                    IntChunk::Float => return json_err!(FloatExpectingInt, new_index),
                 }
             }
         }
@@ -573,10 +569,11 @@ impl AbstractNumberDecoder for NumberRange {
             }
             return Ok((Self::int(start..index), index));
         }
+        let digit_start = start + usize::from(!positive);
         loop {
             let (chunk, new_index) = decode_int_chunk_big(data, index);
-            if (new_index - start) > 4300 {
-                return json_err!(NumberOutOfRange, start + 4301);
+            if (new_index - digit_start) > 4300 {
+                return json_err!(NumberOutOfRange, digit_start + 4301);
             }
             #[allow(clippy::single_match_else)]
             match chunk {

--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -12,7 +12,9 @@ use lexical_parse_float::{FromLexicalWithOptions, Options as ParseFloatOptions, 
 use crate::{
     JsonErrorType::FloatExpectingInt,
     errors::{JsonError, JsonResult, json_err, json_error},
-    simd::{decode_int_chunk_big, decode_int_chunk_small, decode_number_prefix, find_digit_run_end},
+    simd::{
+        ShortInt, decode_int_chunk_big, decode_int_chunk_small, decode_int_digits, decode_short_int, find_digit_run_end,
+    },
 };
 use lexical_format::JSON;
 
@@ -183,7 +185,7 @@ impl AbstractNumberDecoder for NumberAny {
         };
 
         let digit_start = index;
-        let int_prefix = match first {
+        let scan_digits = match first {
             b'I' => {
                 return consume_inf_f64(data, index, positive, allow_inf_nan)
                     .map(|(float, end)| (Self::Float(float), end));
@@ -192,32 +194,26 @@ impl AbstractNumberDecoder for NumberAny {
                 index += 1;
                 match data.get(index) {
                     Some(digit) if digit.is_ascii_digit() => return json_err!(InvalidNumber, index),
-                    Some(b'.' | b'e' | b'E') => None,
+                    Some(b'.' | b'e' | b'E') => false,
                     _ => return Ok((Self::Int(NumberInt::Int(0)), index)),
                 }
             }
-            b'1'..=b'9' => match decode_number_prefix(data, digit_start) {
-                Some((IntChunk::Done(value), end)) => {
+            b'1'..=b'9' => match decode_short_int(data, digit_start) {
+                Some((ShortInt::Int(value), end)) => {
                     return Ok((Self::Int(short_integer(value, positive)), end));
                 }
-                Some((IntChunk::Float, end)) => {
-                    index = end;
-                    None
-                }
-                Some((IntChunk::Ongoing(_), _)) => {
-                    unreachable!("four-digit prefixes are handled by the digit-run scanner")
-                }
-                None => Some((0, digit_start)),
+                Some((ShortInt::Float, _)) => false,
+                None => true,
             },
             _ => return json_err!(InvalidNumber, index),
         };
 
-        if let Some((prefix, prefix_end)) = int_prefix {
+        if scan_digits {
             let limit = digit_start.saturating_add(4300);
             index = find_digit_run_end(data, index, limit)
                 .ok_or_else(|| json_error!(NumberOutOfRange, digit_start + 4301))?;
             if !matches!(data.get(index), Some(b'.' | b'e' | b'E')) {
-                let int = decode_integer_digits(data, digit_start, index, positive, prefix, prefix_end)?;
+                let int = decode_integer_digits(data, digit_start, index, positive)?;
                 return Ok((Self::Int(int), index));
             }
         }
@@ -235,21 +231,14 @@ fn short_integer(magnitude: u64, positive: bool) -> NumberInt {
     NumberInt::Int(value)
 }
 
-/// Convert a validated decimal digit run, extending any already-decoded prefix and applying its sign.
-fn decode_integer_digits(
-    data: &[u8],
-    digit_start: usize,
-    end: usize,
-    positive: bool,
-    prefix: u64,
-    prefix_end: usize,
-) -> JsonResult<NumberInt> {
+/// Convert a validated decimal digit run and apply its sign.
+#[cfg_attr(
+    feature = "num-bigint",
+    allow(clippy::unnecessary_wraps, reason = "conversion can fail without num-bigint")
+)]
+fn decode_integer_digits(data: &[u8], digit_start: usize, end: usize, positive: bool) -> JsonResult<NumberInt> {
     let magnitude = if end - digit_start <= 19 {
-        Some(
-            data[prefix_end..end]
-                .iter()
-                .fold(prefix, |value, digit| value * 10 + u64::from(digit & 0x0f)),
-        )
+        Some(decode_int_digits(&data[digit_start..end]))
     } else {
         None
     };
@@ -391,7 +380,7 @@ impl NumberInt {
         {
             // silence unused variable warning
             let _ = (ongoing, start);
-            return json_err!(NumberOutOfRange, index);
+            json_err!(NumberOutOfRange, index)
         }
 
         #[cfg(feature = "num-bigint")]

--- a/crates/jiter/src/number_decoder.rs
+++ b/crates/jiter/src/number_decoder.rs
@@ -12,9 +12,7 @@ use lexical_parse_float::{FromLexicalWithOptions, Options as ParseFloatOptions, 
 use crate::{
     JsonErrorType::FloatExpectingInt,
     errors::{JsonError, JsonResult, json_err, json_error},
-    simd::{
-        ShortInt, decode_int_chunk_big, decode_int_chunk_small, decode_int_digits, decode_short_int, find_digit_run_end,
-    },
+    simd::{NumberChunk, decode_int_chunk_big, decode_int_chunk_small, decode_number_chunk, find_digit_run_end},
 };
 use lexical_format::JSON;
 
@@ -165,9 +163,8 @@ impl NumberAny {
 }
 
 impl AbstractNumberDecoder for NumberAny {
-    /// Decode short integers directly; otherwise locate the integer digit-run terminator before
-    /// choosing integer conversion or lexical's public float parser. This avoids accumulating a
-    /// speculative integer mantissa for longer floats while keeping short integers single-pass.
+    /// Decode integers or dispatch floats to lexical's public parser without constructing a
+    /// speculative bigint.
     fn decode(data: &[u8], mut index: usize, mut first: u8, allow_inf_nan: bool) -> JsonResult<(Self, usize)> {
         let start = index;
         let positive = match first {
@@ -198,12 +195,20 @@ impl AbstractNumberDecoder for NumberAny {
                     _ => return Ok((Self::Int(NumberInt::Int(0)), index)),
                 }
             }
-            b'1'..=b'9' => match decode_short_int(data, digit_start) {
-                Some((ShortInt::Int(value), end)) => {
-                    return Ok((Self::Int(short_integer(value, positive)), end));
+            b'1'..=b'9' => match decode_number_chunk(data, digit_start) {
+                (NumberChunk::Int(magnitude), end) => {
+                    let int = if let Some(value) = signed_integer(magnitude, positive) {
+                        NumberInt::Int(value)
+                    } else {
+                        decode_bigint(data, digit_start, end, positive, Some(magnitude))?
+                    };
+                    return Ok((Self::Int(int), end));
                 }
-                Some((ShortInt::Float, _)) => false,
-                None => true,
+                (NumberChunk::Float, _) => false,
+                (NumberChunk::Ongoing, end) => {
+                    index = end;
+                    true
+                }
             },
             _ => return json_err!(InvalidNumber, index),
         };
@@ -213,7 +218,7 @@ impl AbstractNumberDecoder for NumberAny {
             index = find_digit_run_end(data, index, limit)
                 .ok_or_else(|| json_error!(NumberOutOfRange, digit_start + 4301))?;
             if !matches!(data.get(index), Some(b'.' | b'e' | b'E')) {
-                let int = decode_integer_digits(data, digit_start, index, positive)?;
+                let int = decode_bigint(data, digit_start, index, positive, None)?;
                 return Ok((Self::Int(int), index));
             }
         }
@@ -222,42 +227,33 @@ impl AbstractNumberDecoder for NumberAny {
     }
 }
 
-fn short_integer(magnitude: u64, positive: bool) -> NumberInt {
-    let value = if positive {
+fn signed_integer(magnitude: u64, positive: bool) -> Option<i64> {
+    let max_magnitude = if positive { i64::MAX as u64 } else { i64::MAX as u64 + 1 };
+    if magnitude > max_magnitude {
+        return None;
+    }
+    Some(if positive {
         magnitude as i64
     } else {
-        -(magnitude as i64)
-    };
-    NumberInt::Int(value)
+        (magnitude as i64).wrapping_neg()
+    })
 }
 
-/// Convert a validated decimal digit run and apply its sign.
+/// Convert a validated integer outside the signed i64 range, optionally using its decoded magnitude.
 #[cfg_attr(
     feature = "num-bigint",
     allow(clippy::unnecessary_wraps, reason = "conversion can fail without num-bigint")
 )]
-fn decode_integer_digits(data: &[u8], digit_start: usize, end: usize, positive: bool) -> JsonResult<NumberInt> {
-    let magnitude = if end - digit_start <= 19 {
-        Some(decode_int_digits(&data[digit_start..end]))
-    } else {
-        None
-    };
-    let max_magnitude = if positive { i64::MAX as u64 } else { i64::MAX as u64 + 1 };
-    if let Some(magnitude) = magnitude
-        && magnitude <= max_magnitude
-    {
-        let value = if positive {
-            magnitude as i64
-        } else if magnitude == i64::MAX as u64 + 1 {
-            i64::MIN
-        } else {
-            -(magnitude as i64)
-        };
-        return Ok(NumberInt::Int(value));
-    }
-
+fn decode_bigint(
+    data: &[u8],
+    digit_start: usize,
+    end: usize,
+    positive: bool,
+    magnitude: Option<u64>,
+) -> JsonResult<NumberInt> {
     #[cfg(not(feature = "num-bigint"))]
     {
+        let _ = (data, end, positive, magnitude);
         json_err!(NumberOutOfRange, digit_start + 1)
     }
 

--- a/crates/jiter/src/simd/aarch64.rs
+++ b/crates/jiter/src/simd/aarch64.rs
@@ -81,6 +81,19 @@ const ALT_MUL_U16_8: SimdVecu16_8 = simd_const!([100u16, 1u16, 100u16, 1u16, 100
 const ALT_MUL_U32_4: SimdVecu32_4 = simd_const!([10000u32, 1u32, 10000u32, 1u32]);
 
 #[target_feature(enable = "neon")]
+pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize) -> usize {
+    while let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
+        let byte_chunk: &[u8; SIMD_STEP] = byte_chunk.try_into().unwrap();
+        let digit_mask = get_digit_mask(load_slice(byte_chunk));
+        if !is_zero(digit_mask) {
+            return index + find_end(digit_mask) as usize;
+        }
+        index += SIMD_STEP;
+    }
+    super::fallback_int::find_digit_run_end(data, index)
+}
+
+#[target_feature(enable = "neon")]
 pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usize) {
     if let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
         let byte_chunk: &[u8; SIMD_STEP] = byte_chunk.try_into().unwrap();

--- a/crates/jiter/src/simd/aarch64.rs
+++ b/crates/jiter/src/simd/aarch64.rs
@@ -81,16 +81,18 @@ const ALT_MUL_U16_8: SimdVecu16_8 = simd_const!([100u16, 1u16, 100u16, 1u16, 100
 const ALT_MUL_U32_4: SimdVecu32_4 = simd_const!([10000u32, 1u32, 10000u32, 1u32]);
 
 #[target_feature(enable = "neon")]
-pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize) -> usize {
-    while let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
+pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize, limit: usize) -> Option<usize> {
+    while index + SIMD_STEP <= limit
+        && let Some(byte_chunk) = data.get(index..index + SIMD_STEP)
+    {
         let byte_chunk: &[u8; SIMD_STEP] = byte_chunk.try_into().unwrap();
         let digit_mask = get_digit_mask(load_slice(byte_chunk));
         if !is_zero(digit_mask) {
-            return index + find_end(digit_mask) as usize;
+            return Some(index + find_end(digit_mask) as usize);
         }
         index += SIMD_STEP;
     }
-    super::fallback_int::find_digit_run_end(data, index)
+    super::fallback_int::find_digit_run_end(data, index, limit)
 }
 
 #[target_feature(enable = "neon")]

--- a/crates/jiter/src/simd/aarch64.rs
+++ b/crates/jiter/src/simd/aarch64.rs
@@ -80,6 +80,19 @@ const ALT_MUL_U8_16: SimdVecu8_16 = simd_const!([
 const ALT_MUL_U16_8: SimdVecu16_8 = simd_const!([100u16, 1u16, 100u16, 1u16, 100u16, 1u16, 100u16, 1u16]);
 const ALT_MUL_U32_4: SimdVecu32_4 = simd_const!([10000u32, 1u32, 10000u32, 1u32]);
 
+#[cfg(target_endian = "little")]
+#[inline]
+#[target_feature(enable = "neon")]
+pub(super) fn classify_digit_chunk(data: &[u8; 16]) -> ([u64; 2], u32) {
+    let digits = simd_sub_16(load_slice(data), ZERO_DIGIT_16);
+    let mask = simd_gt_16(digits, simd_sub_16(NINE_DIGIT_16, ZERO_DIGIT_16));
+    let count = mask_to_u64(mask).trailing_zeros() / 4;
+    // SAFETY: the SIMD vector and integer array are both 16 bytes. The caller selects this
+    // implementation only on little-endian targets.
+    let digits: [u64; 2] = unsafe { transmute(digits) };
+    (digits, count)
+}
+
 #[target_feature(enable = "neon")]
 pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize, limit: usize) -> Option<usize> {
     while index + SIMD_STEP <= limit

--- a/crates/jiter/src/simd/fallback_int.rs
+++ b/crates/jiter/src/simd/fallback_int.rs
@@ -17,23 +17,14 @@ pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize, limit: usize) ->
     }
 }
 
-/// Fuse termination and value decoding for common short integers, using a bulk check before
-/// falling back to the digit-run scanner when at least four digits are present.
+/// Fuse termination and value decoding for numbers shorter than four digits. Returns `None` when
+/// at least four digits are present so the caller can scan the run from its SIMD-friendly start.
 #[inline(always)]
-pub(crate) fn decode_number_prefix(data: &[u8], index: usize) -> (IntChunk, usize) {
-    if let Some(digits) = data.get(index..index + 4)
-        && digits[0].is_ascii_digit()
-        && digits[1].is_ascii_digit()
-        && digits[2].is_ascii_digit()
-        && digits[3].is_ascii_digit()
-    {
-        let value = u64::from(digits[0] & 0x0f) * 1000
-            + u64::from(digits[1] & 0x0f) * 100
-            + u64::from(digits[2] & 0x0f) * 10
-            + u64::from(digits[3] & 0x0f);
-        (IntChunk::Ongoing(value), index + 4)
+pub(crate) fn decode_number_prefix(data: &[u8], index: usize) -> Option<(IntChunk, usize)> {
+    if data.get(index + 3).is_some_and(u8::is_ascii_digit) {
+        None
     } else {
-        decode_int_chunk_limit::<4>(data, index, 0)
+        Some(decode_int_chunk_limit::<4>(data, index, 0))
     }
 }
 

--- a/crates/jiter/src/simd/fallback_int.rs
+++ b/crates/jiter/src/simd/fallback_int.rs
@@ -1,23 +1,54 @@
 use crate::number_decoder::{INT_CHAR_MAP, IntChunk};
 
 #[inline(always)]
-pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize) -> usize {
-    while let Some(digit) = data.get(index) {
+pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize, limit: usize) -> Option<usize> {
+    while index < limit {
+        let Some(digit) = data.get(index) else {
+            return Some(index);
+        };
         if !INT_CHAR_MAP[*digit as usize] {
-            break;
+            return Some(index);
         }
         index += 1;
     }
-    index
+    match data.get(index) {
+        Some(digit) if INT_CHAR_MAP[*digit as usize] => None,
+        _ => Some(index),
+    }
+}
+
+/// Fuse termination and value decoding for common short integers, using a bulk check before
+/// falling back to the digit-run scanner when at least four digits are present.
+#[inline(always)]
+pub(crate) fn decode_number_prefix(data: &[u8], index: usize) -> (IntChunk, usize) {
+    if let Some(digits) = data.get(index..index + 4)
+        && digits[0].is_ascii_digit()
+        && digits[1].is_ascii_digit()
+        && digits[2].is_ascii_digit()
+        && digits[3].is_ascii_digit()
+    {
+        let value = u64::from(digits[0] & 0x0f) * 1000
+            + u64::from(digits[1] & 0x0f) * 100
+            + u64::from(digits[2] & 0x0f) * 10
+            + u64::from(digits[3] & 0x0f);
+        (IntChunk::Ongoing(value), index + 4)
+    } else {
+        decode_int_chunk_limit::<4>(data, index, 0)
+    }
 }
 
 /// Turns out this is faster than fancy bit manipulation, see
 /// https://github.com/Alexhuszagh/rust-lexical/blob/main/lexical-parse-integer/docs/Algorithm.md
 /// for some context
 #[inline(always)]
-pub(crate) fn decode_int_chunk(data: &[u8], mut index: usize, mut value: u64) -> (IntChunk, usize) {
+pub(crate) fn decode_int_chunk(data: &[u8], index: usize, value: u64) -> (IntChunk, usize) {
     // i64::MAX = 9223372036854775807 (19 chars) - so 18 chars is always valid as an i64
-    for _ in 0..18 {
+    decode_int_chunk_limit::<18>(data, index, value)
+}
+
+#[inline(always)]
+fn decode_int_chunk_limit<const LIMIT: usize>(data: &[u8], mut index: usize, mut value: u64) -> (IntChunk, usize) {
+    for _ in 0..LIMIT {
         if let Some(digit) = data.get(index) {
             if INT_CHAR_MAP[*digit as usize] {
                 // we use wrapping add to avoid branching - we know the value cannot wrap

--- a/crates/jiter/src/simd/fallback_int.rs
+++ b/crates/jiter/src/simd/fallback_int.rs
@@ -1,5 +1,16 @@
 use crate::number_decoder::{INT_CHAR_MAP, IntChunk};
 
+#[inline(always)]
+pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize) -> usize {
+    while let Some(digit) = data.get(index) {
+        if !INT_CHAR_MAP[*digit as usize] {
+            break;
+        }
+        index += 1;
+    }
+    index
+}
+
 /// Turns out this is faster than fancy bit manipulation, see
 /// https://github.com/Alexhuszagh/rust-lexical/blob/main/lexical-parse-integer/docs/Algorithm.md
 /// for some context

--- a/crates/jiter/src/simd/fallback_int.rs
+++ b/crates/jiter/src/simd/fallback_int.rs
@@ -17,15 +17,25 @@ pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize, limit: usize) ->
     }
 }
 
-/// Fuse termination and value decoding for numbers shorter than four digits. Returns `None` when
-/// at least four digits are present so the caller can scan the run from its SIMD-friendly start.
+pub(crate) enum ShortInt {
+    Int(u64),
+    Float,
+}
+
+/// Decode a short integer or identify a float marker. Returns `None` when the fourth byte is
+/// a digit, without validating the preceding bytes; the caller must scan from `index`.
 #[inline(always)]
-pub(crate) fn decode_number_prefix(data: &[u8], index: usize) -> Option<(IntChunk, usize)> {
+pub(crate) fn decode_short_int(data: &[u8], index: usize) -> Option<(ShortInt, usize)> {
     if data.get(index + 3).is_some_and(u8::is_ascii_digit) {
-        None
-    } else {
-        Some(decode_int_chunk_limit::<4>(data, index, 0))
+        return None;
     }
+    let (chunk, end) = decode_int_chunk_limit::<4>(data, index, 0);
+    let prefix = match chunk {
+        IntChunk::Done(value) => ShortInt::Int(value),
+        IntChunk::Float => ShortInt::Float,
+        IntChunk::Ongoing(_) => unreachable!("the fourth byte is not a digit"),
+    };
+    Some((prefix, end))
 }
 
 /// Turns out this is faster than fancy bit manipulation, see

--- a/crates/jiter/src/simd/fallback_int.rs
+++ b/crates/jiter/src/simd/fallback_int.rs
@@ -17,25 +17,15 @@ pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize, limit: usize) ->
     }
 }
 
-pub(crate) enum ShortInt {
-    Int(u64),
-    Float,
-}
-
-/// Decode a short integer or identify a float marker. Returns `None` when the fourth byte is
-/// a digit, without validating the preceding bytes; the caller must scan from `index`.
+#[cfg(not(any(target_arch = "x86_64", all(target_arch = "aarch64", target_endian = "little"))))]
 #[inline(always)]
-pub(crate) fn decode_short_int(data: &[u8], index: usize) -> Option<(ShortInt, usize)> {
-    if data.get(index + 3).is_some_and(u8::is_ascii_digit) {
-        return None;
-    }
-    let (chunk, end) = decode_int_chunk_limit::<4>(data, index, 0);
-    let prefix = match chunk {
-        IntChunk::Done(value) => ShortInt::Int(value),
-        IntChunk::Float => ShortInt::Float,
-        IntChunk::Ongoing(_) => unreachable!("the fourth byte is not a digit"),
-    };
-    Some((prefix, end))
+pub(super) fn classify_digit_chunk(data: &[u8; 16]) -> ([u64; 2], u32) {
+    let count = data.iter().position(|digit| !digit.is_ascii_digit()).unwrap_or(16);
+    let words = [data[..8].try_into().unwrap(), data[8..].try_into().unwrap()];
+    (
+        words.map(|word| u64::from_le_bytes(word) & 0x0F0F_0F0F_0F0F_0F0F),
+        count as u32,
+    )
 }
 
 /// Turns out this is faster than fancy bit manipulation, see

--- a/crates/jiter/src/simd/mod.rs
+++ b/crates/jiter/src/simd/mod.rs
@@ -40,6 +40,24 @@ pub(crate) fn decode_string_chunk(
 }
 
 #[inline(always)]
+pub(crate) fn find_digit_run_end(data: &[u8], index: usize) -> usize {
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: all supported aarch64 targets support neon intrinsics.
+        unsafe { aarch64::find_digit_run_end(data, index) }
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SAFETY: SSE2 is part of the x86_64 baseline.
+        unsafe { x86_64::find_digit_run_end(data, index) }
+    }
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    {
+        fallback_int::find_digit_run_end(data, index)
+    }
+}
+
+#[inline(always)]
 pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usize) {
     #[cfg(target_arch = "aarch64")]
     {

--- a/crates/jiter/src/simd/mod.rs
+++ b/crates/jiter/src/simd/mod.rs
@@ -5,16 +5,22 @@ mod fallback_string;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
-pub(crate) use fallback_int::decode_int_chunk as decode_int_chunk_small;
+pub(crate) use fallback_int::{decode_int_chunk as decode_int_chunk_small, decode_number_prefix};
 
 use crate::errors::JsonResult;
 use crate::number_decoder::IntChunk;
 use crate::string_decoder::StringChunk;
 
 /// the number of digits consumed per `IntChunk::Ongoing` chunk from `decode_int_chunk_big`
-#[cfg(all(feature = "num-bigint", any(target_arch = "aarch64", target_arch = "x86_64")))]
+#[cfg(all(
+    feature = "num-bigint",
+    any(target_arch = "x86_64", all(target_arch = "aarch64", target_endian = "little"))
+))]
 pub(crate) const ONGOING_CHUNK_MULTIPLIER: u64 = 10u64.pow(16);
-#[cfg(all(feature = "num-bigint", not(any(target_arch = "aarch64", target_arch = "x86_64"))))]
+#[cfg(all(
+    feature = "num-bigint",
+    not(any(target_arch = "x86_64", all(target_arch = "aarch64", target_endian = "little")))
+))]
 pub(crate) const ONGOING_CHUNK_MULTIPLIER: u64 = 10u64.pow(18);
 
 #[inline(always)]
@@ -40,26 +46,26 @@ pub(crate) fn decode_string_chunk(
 }
 
 #[inline(always)]
-pub(crate) fn find_digit_run_end(data: &[u8], index: usize) -> usize {
-    #[cfg(target_arch = "aarch64")]
+pub(crate) fn find_digit_run_end(data: &[u8], index: usize, limit: usize) -> Option<usize> {
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     {
         // SAFETY: all supported aarch64 targets support neon intrinsics.
-        unsafe { aarch64::find_digit_run_end(data, index) }
+        unsafe { aarch64::find_digit_run_end(data, index, limit) }
     }
     #[cfg(target_arch = "x86_64")]
     {
         // SAFETY: SSE2 is part of the x86_64 baseline.
-        unsafe { x86_64::find_digit_run_end(data, index) }
+        unsafe { x86_64::find_digit_run_end(data, index, limit) }
     }
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    #[cfg(not(any(target_arch = "x86_64", all(target_arch = "aarch64", target_endian = "little"))))]
     {
-        fallback_int::find_digit_run_end(data, index)
+        fallback_int::find_digit_run_end(data, index, limit)
     }
 }
 
 #[inline(always)]
 pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usize) {
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     {
         // SAFETY: all supported aarch64 targets support neon intrinsics
         unsafe { aarch64::decode_int_chunk_big(data, index) }
@@ -69,7 +75,7 @@ pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usiz
         // SAFETY: SSE2 is part of the x86_64 baseline.
         unsafe { x86_64::decode_int_chunk_big(data, index) }
     }
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    #[cfg(not(any(target_arch = "x86_64", all(target_arch = "aarch64", target_endian = "little"))))]
     {
         fallback_int::decode_int_chunk(data, index, 0)
     }

--- a/crates/jiter/src/simd/mod.rs
+++ b/crates/jiter/src/simd/mod.rs
@@ -2,12 +2,13 @@
 mod aarch64;
 mod fallback_int;
 mod fallback_string;
+mod number;
 mod swar_int;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
-pub(crate) use fallback_int::{ShortInt, decode_int_chunk as decode_int_chunk_small, decode_short_int};
-pub(crate) use swar_int::decode_digits as decode_int_digits;
+pub(crate) use fallback_int::decode_int_chunk as decode_int_chunk_small;
+pub(crate) use number::{NumberChunk, decode_number_chunk};
 
 use crate::errors::JsonResult;
 use crate::number_decoder::IntChunk;
@@ -44,6 +45,26 @@ pub(crate) fn decode_string_chunk(
     #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
     {
         fallback_string::decode_string_chunk(data, index, ascii_only, allow_partial)
+    }
+}
+
+/// Classify sixteen bytes, returning digit values in little-endian byte order and the digit
+/// count. Bytes after the first non-digit have unspecified values.
+#[inline(always)]
+fn classify_digit_chunk(data: &[u8; 16]) -> ([u64; 2], u32) {
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    {
+        // SAFETY: all supported aarch64 targets support neon intrinsics.
+        unsafe { aarch64::classify_digit_chunk(data) }
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SAFETY: SSE2 is part of the x86_64 baseline.
+        unsafe { x86_64::classify_digit_chunk(data) }
+    }
+    #[cfg(not(any(target_arch = "x86_64", all(target_arch = "aarch64", target_endian = "little"))))]
+    {
+        fallback_int::classify_digit_chunk(data)
     }
 }
 

--- a/crates/jiter/src/simd/mod.rs
+++ b/crates/jiter/src/simd/mod.rs
@@ -2,10 +2,12 @@
 mod aarch64;
 mod fallback_int;
 mod fallback_string;
+mod swar_int;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
-pub(crate) use fallback_int::{decode_int_chunk as decode_int_chunk_small, decode_number_prefix};
+pub(crate) use fallback_int::{ShortInt, decode_int_chunk as decode_int_chunk_small, decode_short_int};
+pub(crate) use swar_int::decode_digits as decode_int_digits;
 
 use crate::errors::JsonResult;
 use crate::number_decoder::IntChunk;

--- a/crates/jiter/src/simd/number.rs
+++ b/crates/jiter/src/simd/number.rs
@@ -1,0 +1,57 @@
+use super::{classify_digit_chunk, fallback_int, swar_int};
+use crate::number_decoder::IntChunk;
+
+pub(crate) enum NumberChunk {
+    Int(u64),
+    Float,
+    Ongoing,
+}
+
+/// Decode a number prefix starting with a nonzero digit. On `Ongoing`, resume scanning at
+/// the returned index.
+#[inline(always)]
+pub(crate) fn decode_number_chunk(data: &[u8], mut index: usize) -> (NumberChunk, usize) {
+    let Some(bytes) = data.get(index..index + 16) else {
+        return decode_tail(data, index);
+    };
+    let (digits, count) = classify_digit_chunk(bytes.try_into().unwrap());
+    if count < 16 {
+        let end = index + count as usize;
+        return match data.get(end) {
+            Some(b'.' | b'e' | b'E') => (NumberChunk::Float, end),
+            _ => (NumberChunk::Int(swar_int::decode_digits(digits, count)), end),
+        };
+    }
+
+    index += 16;
+    let mut tail = 0;
+    let mut multiplier = 1;
+    for _ in 0..3 {
+        let Some(digit) = data.get(index).filter(|digit| digit.is_ascii_digit()) else {
+            break;
+        };
+        tail = tail * 10 + u64::from(digit & 0x0f);
+        multiplier *= 10;
+        index += 1;
+    }
+    match data.get(index) {
+        Some(digit) if digit.is_ascii_digit() => (NumberChunk::Ongoing, index),
+        Some(b'.' | b'e' | b'E') => (NumberChunk::Float, index),
+        _ => (
+            NumberChunk::Int(swar_int::decode_digits(digits, 16) * multiplier + tail),
+            index,
+        ),
+    }
+}
+
+#[cold]
+#[inline(never)]
+fn decode_tail(data: &[u8], index: usize) -> (NumberChunk, usize) {
+    let (chunk, end) = fallback_int::decode_int_chunk(data, index, 0);
+    let value = match chunk {
+        IntChunk::Done(value) => NumberChunk::Int(value),
+        IntChunk::Float => NumberChunk::Float,
+        IntChunk::Ongoing(_) => unreachable!("fewer than sixteen bytes remain"),
+    };
+    (value, end)
+}

--- a/crates/jiter/src/simd/swar_int.rs
+++ b/crates/jiter/src/simd/swar_int.rs
@@ -1,30 +1,24 @@
-//! Uses in-register instructions to decode ASCII digits into a `u64`.
+//! Uses in-register instructions to decode digit values into a `u64`.
 //!
 //! See <https://lemire.me/blog/2022/01/21/swar-explained-parsing-eight-digits/>
 
-/// Convert validated ASCII digits to a magnitude that must fit in a `u64`.
-///
-/// Will produce a garbage value if the input is not valid ASCII digits (max 19 digits).
+/// Convert 1–16 validated digits, packed in little-endian byte order with values 0–9.
+/// Bytes after `count` are ignored.
 #[inline]
-pub(crate) fn decode_digits(data: &[u8]) -> u64 {
-    debug_assert!(data.iter().all(|&digit| digit.is_ascii_digit()));
-    debug_assert!(data.len() <= 19, "maximum 19 digits allowed");
-
-    let mut value = 0;
-    let (chunks, remainder) = data.as_chunks::<8>();
-    for chunk in chunks {
-        value = value * 100_000_000 + decode_eight_digits(u64::from_le_bytes(*chunk));
+pub(super) fn decode_digits(digits: [u64; 2], count: u32) -> u64 {
+    const POW10: [u64; 9] = [1, 10, 100, 1000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000];
+    debug_assert!((1..=16).contains(&count));
+    if count <= 8 {
+        decode_eight_digits(digits[0] << ((8 - count) * 8))
+    } else {
+        decode_eight_digits(digits[0]) * POW10[(count - 8) as usize]
+            + decode_eight_digits(digits[1] << ((16 - count) * 8))
     }
-    remainder
-        .iter()
-        .fold(value, |value, digit| value * 10 + u64::from(digit & 0x0f))
 }
 
-/// Convert eight validated ASCII digits packed in little-endian order.
 #[inline]
-fn decode_eight_digits(word: u64) -> u64 {
+fn decode_eight_digits(value: u64) -> u64 {
     const MASK: u64 = 0x0000_00FF_0000_00FF;
-    let value = word.wrapping_sub(0x3030_3030_3030_3030);
     let value = value.wrapping_mul(2561) >> 8;
     (value & MASK)
         .wrapping_mul(0x000F_4240_0000_0064)

--- a/crates/jiter/src/simd/swar_int.rs
+++ b/crates/jiter/src/simd/swar_int.rs
@@ -1,0 +1,33 @@
+//! Uses in-register instructions to decode ASCII digits into a `u64`.
+//!
+//! See <https://lemire.me/blog/2022/01/21/swar-explained-parsing-eight-digits/>
+
+/// Convert validated ASCII digits to a magnitude that must fit in a `u64`.
+///
+/// Will produce a garbage value if the input is not valid ASCII digits (max 19 digits).
+#[inline]
+pub(crate) fn decode_digits(data: &[u8]) -> u64 {
+    debug_assert!(data.iter().all(|&digit| (b'0'..=b'9').contains(&digit)));
+    debug_assert!(data.len() <= 19, "maximum 19 digits allowed");
+
+    let mut value = 0;
+    let (chunks, remainder) = data.as_chunks::<8>();
+    for chunk in chunks {
+        value = value * 100_000_000 + decode_eight_digits(u64::from_le_bytes(*chunk));
+    }
+    remainder
+        .iter()
+        .fold(value, |value, digit| value * 10 + u64::from(digit & 0x0f))
+}
+
+/// Convert eight validated ASCII digits packed in little-endian order.
+#[inline]
+fn decode_eight_digits(word: u64) -> u64 {
+    const MASK: u64 = 0x0000_00FF_0000_00FF;
+    let value = word.wrapping_sub(0x3030_3030_3030_3030);
+    let value = value.wrapping_mul(2561) >> 8;
+    (value & MASK)
+        .wrapping_mul(0x000F_4240_0000_0064)
+        .wrapping_add(((value >> 16) & MASK).wrapping_mul(0x0000_2710_0000_0001))
+        >> 32
+}

--- a/crates/jiter/src/simd/swar_int.rs
+++ b/crates/jiter/src/simd/swar_int.rs
@@ -7,7 +7,7 @@
 /// Will produce a garbage value if the input is not valid ASCII digits (max 19 digits).
 #[inline]
 pub(crate) fn decode_digits(data: &[u8]) -> u64 {
-    debug_assert!(data.iter().all(|&digit| (b'0'..=b'9').contains(&digit)));
+    debug_assert!(data.iter().all(|&digit| digit.is_ascii_digit()));
     debug_assert!(data.len() <= 19, "maximum 19 digits allowed");
 
     let mut value = 0;

--- a/crates/jiter/src/simd/x86_64.rs
+++ b/crates/jiter/src/simd/x86_64.rs
@@ -45,16 +45,18 @@ const ALT_MUL_U32_4: SimdVec = simd_const!([10000u32, 0u32, 10000u32, 0u32]);
 
 #[inline]
 #[target_feature(enable = "sse2")]
-pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize) -> usize {
-    while let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
+pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize, limit: usize) -> Option<usize> {
+    while index + SIMD_STEP <= limit
+        && let Some(byte_chunk) = data.get(index..index + SIMD_STEP)
+    {
         let digits = simd_sub_16(load_slice(byte_chunk), ZERO_DIGIT_16);
         let last_digit = first_non_digit(digits);
         if last_digit != SIMD_STEP as u32 {
-            return index + last_digit as usize;
+            return Some(index + last_digit as usize);
         }
         index += SIMD_STEP;
     }
-    super::fallback_int::find_digit_run_end(data, index)
+    super::fallback_int::find_digit_run_end(data, index, limit)
 }
 
 #[inline]

--- a/crates/jiter/src/simd/x86_64.rs
+++ b/crates/jiter/src/simd/x86_64.rs
@@ -45,6 +45,20 @@ const ALT_MUL_U32_4: SimdVec = simd_const!([10000u32, 0u32, 10000u32, 0u32]);
 
 #[inline]
 #[target_feature(enable = "sse2")]
+pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize) -> usize {
+    while let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
+        let digits = simd_sub_16(load_slice(byte_chunk), ZERO_DIGIT_16);
+        let last_digit = first_non_digit(digits);
+        if last_digit != SIMD_STEP as u32 {
+            return index + last_digit as usize;
+        }
+        index += SIMD_STEP;
+    }
+    super::fallback_int::find_digit_run_end(data, index)
+}
+
+#[inline]
+#[target_feature(enable = "sse2")]
 pub(crate) fn decode_int_chunk_big(data: &[u8], index: usize) -> (IntChunk, usize) {
     if let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
         let byte_vec = load_slice(byte_chunk);

--- a/crates/jiter/src/simd/x86_64.rs
+++ b/crates/jiter/src/simd/x86_64.rs
@@ -45,6 +45,16 @@ const ALT_MUL_U32_4: SimdVec = simd_const!([10000u32, 0u32, 10000u32, 0u32]);
 
 #[inline]
 #[target_feature(enable = "sse2")]
+pub(super) fn classify_digit_chunk(data: &[u8; 16]) -> ([u64; 2], u32) {
+    let digits = simd_sub_16(load_slice(data), ZERO_DIGIT_16);
+    let count = first_non_digit(digits);
+    // SAFETY: the SIMD vector and integer array are both 16 bytes; x86_64 is little-endian.
+    let digits: [u64; 2] = unsafe { transmute(digits) };
+    (digits, count)
+}
+
+#[inline]
+#[target_feature(enable = "sse2")]
 pub(crate) fn find_digit_run_end(data: &[u8], mut index: usize, limit: usize) -> Option<usize> {
     while index + SIMD_STEP <= limit
         && let Some(byte_chunk) = data.get(index..index + SIMD_STEP)

--- a/crates/jiter/tests/main.rs
+++ b/crates/jiter/tests/main.rs
@@ -1279,6 +1279,18 @@ fn jiter_next_value_owned() {
     assert!(matches!(s, Cow::Owned(_)));
 }
 
+#[test]
+fn number_any_i64_boundaries() {
+    assert_eq!(
+        NumberAny::from_bytes(b"9223372036854775807", false).unwrap(),
+        NumberAny::Int(NumberInt::Int(i64::MAX))
+    );
+    assert_eq!(
+        NumberAny::from_bytes(b"-9223372036854775808", false).unwrap(),
+        NumberAny::Int(NumberInt::Int(i64::MIN))
+    );
+}
+
 #[cfg(feature = "num-bigint")]
 #[test]
 fn i64_max() {

--- a/crates/jiter/tests/main.rs
+++ b/crates/jiter/tests/main.rs
@@ -1024,6 +1024,34 @@ fn test_4300_int() {
 
 #[cfg(feature = "num-bigint")]
 #[test]
+fn signed_integer_digit_limit() {
+    for sign in ["", "-"] {
+        for digits in [4299, 4300, 4301] {
+            let json = format!("{sign}{}", "9".repeat(digits));
+            let bytes = json.as_bytes();
+            let any = NumberAny::from_bytes(bytes, false);
+            let int = NumberInt::from_bytes(bytes);
+            let mut jiter = Jiter::new(bytes);
+            let range = jiter.next_number_bytes();
+            if digits <= 4300 {
+                let expected = BigInt::from_str(&json).unwrap();
+                assert_eq!(any.unwrap(), NumberAny::Int(NumberInt::BigInt(expected.clone())));
+                assert_eq!(int.unwrap(), NumberInt::BigInt(expected));
+                assert_eq!(range.unwrap(), bytes);
+            } else {
+                let expected_index = sign.len() + 4301;
+                for error in [any.unwrap_err(), int.unwrap_err()] {
+                    assert_eq!(error.error_type, JsonErrorType::NumberOutOfRange);
+                    assert_eq!(error.index, expected_index);
+                }
+                assert!(range.is_err());
+            }
+        }
+    }
+}
+
+#[cfg(feature = "num-bigint")]
+#[test]
 fn test_big_int_errs() {
     for json in [
         &[b'9'; 4302][..],

--- a/crates/jiter/tests/main.rs
+++ b/crates/jiter/tests/main.rs
@@ -1316,6 +1316,8 @@ fn number_any_chunk_boundaries() {
         123_456_789_012_345,
         1_234_567_890_123_456,
         12_345_678_901_234_567,
+        123_456_789_012_345_678,
+        1_234_567_890_123_456_789,
     ] {
         for value in [integer, -integer] {
             for suffix in ["", ".125", "e-3", "E+3"] {
@@ -1334,6 +1336,23 @@ fn number_any_chunk_boundaries() {
                     }
                 }
             }
+        }
+    }
+}
+
+#[test]
+fn number_any_non_digit_terminators() {
+    for len in [1, 3, 7, 8, 9, 15, 16, 17, 18, 19] {
+        let token = &"1234567890123456789"[..len];
+        let expected = NumberAny::Int(NumberInt::Int(token.parse().unwrap()));
+        for &byte in b"/:\x00\x80\xff]" {
+            let mut data = b"       ".to_vec();
+            data.extend_from_slice(token.as_bytes());
+            data.push(byte);
+            data.extend_from_slice(b"12345678901234567890]");
+            let mut jiter = Jiter::new(&data);
+            assert_eq!(jiter.next_number().unwrap(), expected, "{data:?}");
+            assert_eq!(jiter.current_index(), 7 + len, "{data:?}");
         }
     }
 }

--- a/crates/jiter/tests/main.rs
+++ b/crates/jiter/tests/main.rs
@@ -1308,6 +1308,37 @@ fn jiter_next_value_owned() {
 }
 
 #[test]
+fn number_any_chunk_boundaries() {
+    for integer in [
+        1_234_567i64,
+        12_345_678,
+        123_456_789,
+        123_456_789_012_345,
+        1_234_567_890_123_456,
+        12_345_678_901_234_567,
+    ] {
+        for value in [integer, -integer] {
+            for suffix in ["", ".125", "e-3", "E+3"] {
+                let token = format!("{value}{suffix}");
+                let expected = if suffix.is_empty() {
+                    NumberAny::Int(NumberInt::Int(value))
+                } else {
+                    NumberAny::Float(token.parse::<f64>().unwrap())
+                };
+                for offset in [0, 1, 7, 15] {
+                    for trailing in ["", ", 12345678901234567890]"] {
+                        let data = format!("{}{token}{trailing}", " ".repeat(offset));
+                        let mut jiter = Jiter::new(data.as_bytes());
+                        assert_eq!(jiter.next_number().unwrap(), expected, "{data}");
+                        assert_eq!(jiter.current_index(), offset + token.len(), "{data}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
 fn number_any_i64_boundaries() {
     assert_eq!(
         NumberAny::from_bytes(b"9223372036854775807", false).unwrap(),
@@ -1317,6 +1348,16 @@ fn number_any_i64_boundaries() {
         NumberAny::from_bytes(b"-9223372036854775808", false).unwrap(),
         NumberAny::Int(NumberInt::Int(i64::MIN))
     );
+    for json in ["9223372036854775808", "-9223372036854775809"] {
+        let result = NumberAny::from_bytes(json.as_bytes(), false);
+        #[cfg(feature = "num-bigint")]
+        assert_eq!(
+            result.unwrap(),
+            NumberAny::Int(NumberInt::BigInt(json.parse::<BigInt>().unwrap()))
+        );
+        #[cfg(not(feature = "num-bigint"))]
+        assert_eq!(result.unwrap_err().error_type, JsonErrorType::NumberOutOfRange);
+    }
 }
 
 #[cfg(feature = "num-bigint")]


### PR DESCRIPTION
Possible alternative to #281 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors number decoding to scan the digit run first, then decide between integer and float paths. This avoids a speculative float parse for integers and simplifies error handling by eliminating a re-parse fallback.

**Changed**
- Adds SIMD digit-run scanning for x86_64 and aarch64, with SWAR decoding of short integers in the same pass.
- Treats `Infinity` and `NaN` as float inputs in `NumberAny` rather than separate enum variants.

<sup>Written for commit 39ac230919d6b6413516fca1043df376c6b196f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

