### PR TITLE
fast-path whitespace extraction

### DIFF
--- a/crates/jiter/src/parse.rs
+++ b/crates/jiter/src/parse.rs
@@ -251,6 +251,15 @@ impl<'j> Parser<'j> {
     }
 
     fn eat_whitespace(&mut self) -> Option<u8> {
+        match self.data.get(self.index) {
+            Some(b' ' | b'\r' | b'\t' | b'\n') => self.consume_whitespace(),
+            Some(next) => Some(*next),
+            None => None,
+        }
+    }
+
+    fn consume_whitespace(&mut self) -> Option<u8> {
+        self.index += 1;
         while let Some(next) = self.data.get(self.index) {
             match next {
                 b' ' | b'\r' | b'\t' | b'\n' => self.index += 1,


### PR DESCRIPTION
Attempts to encourage a fast-path when there is no whitespace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fast path to whitespace parsing so the parser returns immediately when the next byte isn't whitespace, avoiding an unnecessary loop.

- Splits `eat_whitespace` into a quick check for the next byte and a separate `consume_whitespace` method that runs only when whitespace is actually present.
- No change in behavior or output.

<sup>Written for commit 7ee52f43151c7f606f1160b703d850010dfa2b92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

