### PR TITLE
Run the benchmarks with a realloc that never grows in place

### DIFF
--- a/crates/jiter/benches/json_cases.rs
+++ b/crates/jiter/benches/json_cases.rs
@@ -14,6 +14,10 @@ use serde_json::Value as SerdeValue;
 
 #[path = "../tests/corpus/mod.rs"]
 mod corpus;
+mod slow_realloc;
+
+#[global_allocator]
+static GLOBAL: slow_realloc::SlowRealloc = slow_realloc::SlowRealloc;
 
 use corpus::{TAGS, find_corpus_root, load_cases};
 

--- a/crates/jiter/benches/main.rs
+++ b/crates/jiter/benches/main.rs
@@ -1,3 +1,8 @@
+mod slow_realloc;
+
+#[global_allocator]
+static GLOBAL: slow_realloc::SlowRealloc = slow_realloc::SlowRealloc;
+
 use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
 
 use std::fs::File;

--- a/crates/jiter/benches/python.rs
+++ b/crates/jiter/benches/python.rs
@@ -1,3 +1,8 @@
+mod slow_realloc;
+
+#[global_allocator]
+static GLOBAL: slow_realloc::SlowRealloc = slow_realloc::SlowRealloc;
+
 use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
 
 use std::fs::File;

--- a/crates/jiter/benches/slow_realloc/mod.rs
+++ b/crates/jiter/benches/slow_realloc/mod.rs
@@ -1,0 +1,34 @@
+//! A global allocator whose `realloc` always allocates, copies and frees, never grows in place.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+
+pub struct SlowRealloc;
+
+unsafe impl GlobalAlloc for SlowRealloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: the caller upholds the `GlobalAlloc::realloc` contract, so `ptr` is a live block
+        // of `layout` and `new_size` is a valid size for `layout.align()`; the copy is bounded by
+        // the smaller of the two sizes.
+        unsafe {
+            let new_layout = Layout::from_size_align_unchecked(new_size, layout.align());
+            let new_ptr = System.alloc(new_layout);
+            if !new_ptr.is_null() {
+                std::ptr::copy_nonoverlapping(ptr, new_ptr, layout.size().min(new_size));
+                System.dealloc(ptr, layout);
+            }
+            new_ptr
+        }
+    }
+}


### PR DESCRIPTION
Several benchmarks flip between two values on identical code, and get blamed on whichever PR happens to be open. Across the last runs on `main` and #289, all with rustc 1.98.1 and cargo-codspeed 5.0.1:

| benchmark | state A | state B |
|---|---|---|
| `true_array_jiter_value` | 2.72 µs | 3.10 µs |
| `string_array_jiter_value_owned` | 16.1 µs | 17.6 µs |

Within a run the stdev is 0.15%, so each process is locked into one state for its whole life. The two states' flame graphs differ in one place: in the fast state glibc's `realloc` extends the growing `Vec<JsonValue>` in place; in the slow state the neighbouring chunk is occupied, so `realloc` goes through `int_malloc` and `memcpy`. That's decided by heap layout at start-up, not by the code, and it is the case CodSpeed's [variance guide](https://codspeed.io/docs/instruments/cpu/reducing-variance.md) singles out.

The three bench binaries now install a global allocator whose `realloc` always allocates, copies and frees. Reported times for realloc-heavy benchmarks settle on the slow state, so this PR will itself show "regressions" on those once, to be acknowledged. After that they should stop moving.

Not covered: `python_parse_x100` (132 vs 140 ns) and `python_parse_numeric` (1.3 vs 1.5 µs) flip the same way, but their allocations go through pymalloc, which this doesn't touch.

Follow-up worth considering in the library rather than the benches: `take_value_recursive` starts its shared `elements` Vec at capacity 8 on every parse and grows it by `push`, so a 100-element array reallocs five times before `take_container` copies it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm4KCoN9xWsA4HRCL3Lx63


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Benchmarks now use a global allocator whose `realloc` never grows in place, so realloc-heavy benchmarks consistently land on the slow path instead of flipping between two values on identical code. This prevents unrelated PRs from being blamed for 15% noise.

- The three bench binaries install the `slow_realloc::SlowRealloc` allocator.
- Realloc-heavy benchmarks will show a one-time "regression" on this PR as they settle on the slow state, after which they should stop moving.
- `python_parse_x100` and `python_parse_numeric` are not covered because their allocations go through pymalloc.

<sup>Written for commit 1062a4536dcde6607e2b8dc20934331c1774620e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

