### PR TITLE
Size the value stacks from the last parse

### DIFF
--- a/crates/jiter/src/parse.rs
+++ b/crates/jiter/src/parse.rs
@@ -69,6 +69,10 @@ impl<'j> Parser<'j> {
         Self { data, index: 0 }
     }
 
+    pub(crate) fn remaining_len(&self) -> usize {
+        self.data.len().saturating_sub(self.index)
+    }
+
     #[allow(dead_code)]
     pub fn slice(&self, range: Range<usize>) -> Option<&[u8]> {
         self.data.get(range)

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -379,9 +379,9 @@ fn take_value_recursive<'j, 's>(
     // allocation of exactly the right size. A `Vec` per container has to guess that size instead,
     // and pays a run of reallocations for guessing low.
     // The stacks are sized from the peaks of the last parse, capped by what the remaining input
-    // could possibly hold. Only the
-    // root container's stack is allocated up front, the other when its first container opens, so
-    // a document that never opens a container of the other kind never pays for its stack.
+    // could possibly hold. Only the root container's stack is allocated up front; the other kind's
+    // stack is allocated when its first container opens, so a document that never opens a
+    // container of the other kind never pays for one.
     let (mut elements, mut members): (Vec<JsonValue<'s>>, Vec<(Cow<'s, str>, JsonValue<'s>)>) = match &current_recursion
     {
         RecursedValue::Array { .. } => (

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -342,6 +342,15 @@ fn take_container<T>(stack: &mut Vec<T>, base: usize, peak: &mut usize) -> Vec<T
 static ELEMENTS_HINT: AtomicUsize = AtomicUsize::new(8);
 static MEMBERS_HINT: AtomicUsize = AtomicUsize::new(8);
 
+/// Bounds what a hint left by a large document can make a later one allocate up front.
+const STACK_HINT_MAX: usize = 2048;
+
+/// The capacity to give an empty stack: the last parse's peak, capped by what the remaining input
+/// could hold at `min_bytes` per entry.
+fn stack_hint(hint: &AtomicUsize, remaining: usize, min_bytes: usize) -> usize {
+    hint.load(Relaxed).min(STACK_HINT_MAX).min(remaining / min_bytes)
+}
+
 #[inline(never)] // this is an iterative algo called only from take_value, no point in inlining
 #[allow(clippy::too_many_lines)] // FIXME?
 #[allow(clippy::too_many_arguments)]
@@ -363,11 +372,20 @@ fn take_value_recursive<'j, 's>(
     // allocation of exactly the right size. A `Vec` per container has to guess that size instead,
     // and pays a run of reallocations for guessing low.
     // The stacks are sized from the peaks of the last parse, capped by what the remaining input
-    // could possibly hold: an element needs at least two bytes, a member at least five.
-    let remaining = parser.remaining_len();
-    let mut elements: Vec<JsonValue<'s>> = Vec::with_capacity(ELEMENTS_HINT.load(Relaxed).min(remaining / 2));
-    let mut members: Vec<(Cow<'s, str>, JsonValue<'s>)> =
-        Vec::with_capacity(MEMBERS_HINT.load(Relaxed).min(remaining / 5));
+    // could possibly hold: an element needs at least two bytes, a member at least five. Only the
+    // root container's stack is allocated up front, the other when its first container opens, so
+    // a document that never opens a container of the other kind never pays for its stack.
+    let (mut elements, mut members): (Vec<JsonValue<'s>>, Vec<(Cow<'s, str>, JsonValue<'s>)>) = match &current_recursion
+    {
+        RecursedValue::Array { .. } => (
+            Vec::with_capacity(stack_hint(&ELEMENTS_HINT, parser.remaining_len(), 2)),
+            Vec::new(),
+        ),
+        RecursedValue::Object { .. } => (
+            Vec::new(),
+            Vec::with_capacity(stack_hint(&MEMBERS_HINT, parser.remaining_len(), 5)),
+        ),
+    };
     let (mut elements_peak, mut members_peak) = (0, 0);
 
     let mut recursion_stack: SmallVec<[RecursedValue; 8]> = SmallVec::new();
@@ -379,6 +397,15 @@ fn take_value_recursive<'j, 's>(
             recursion_stack.push(std::mem::replace(&mut current_recursion, $value));
             if recursion_stack.len() >= recursion_limit {
                 return Err(json_error!(RecursionLimitExceeded, parser.index));
+            }
+            match &current_recursion {
+                RecursedValue::Array { .. } if elements.capacity() == 0 => {
+                    elements.reserve_exact(stack_hint(&ELEMENTS_HINT, parser.remaining_len(), 2));
+                }
+                RecursedValue::Object { .. } if members.capacity() == 0 => {
+                    members.reserve_exact(stack_hint(&MEMBERS_HINT, parser.remaining_len(), 5));
+                }
+                _ => {}
             }
         };
     }

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -345,10 +345,17 @@ static MEMBERS_HINT: AtomicUsize = AtomicUsize::new(8);
 /// Bounds what a hint left by a large document can make a later one allocate up front.
 const STACK_HINT_MAX: usize = 2048;
 
-/// The capacity to give an empty stack: the last parse's peak, capped by what the remaining input
-/// could hold at `min_bytes` per entry.
-fn stack_hint(hint: &AtomicUsize, remaining: usize, min_bytes: usize) -> usize {
-    hint.load(Relaxed).min(STACK_HINT_MAX).min(remaining / min_bytes)
+/// The capacity to give an empty elements stack: `hint`, capped by how many elements the
+/// `remaining` input could still hold, at two bytes each.
+fn elements_capacity(hint: usize, remaining: usize) -> usize {
+    hint.min(STACK_HINT_MAX).min(remaining / 2)
+}
+
+/// The capacity to give an empty members stack: `hint`, capped by how many members the
+/// `remaining` input could still hold, at five bytes each plus the one whose key is already
+/// consumed when a container opens.
+fn members_capacity(hint: usize, remaining: usize) -> usize {
+    hint.min(STACK_HINT_MAX).min(remaining / 5 + 1)
 }
 
 #[inline(never)] // this is an iterative algo called only from take_value, no point in inlining
@@ -372,18 +379,18 @@ fn take_value_recursive<'j, 's>(
     // allocation of exactly the right size. A `Vec` per container has to guess that size instead,
     // and pays a run of reallocations for guessing low.
     // The stacks are sized from the peaks of the last parse, capped by what the remaining input
-    // could possibly hold: an element needs at least two bytes, a member at least five. Only the
+    // could possibly hold. Only the
     // root container's stack is allocated up front, the other when its first container opens, so
     // a document that never opens a container of the other kind never pays for its stack.
     let (mut elements, mut members): (Vec<JsonValue<'s>>, Vec<(Cow<'s, str>, JsonValue<'s>)>) = match &current_recursion
     {
         RecursedValue::Array { .. } => (
-            Vec::with_capacity(stack_hint(&ELEMENTS_HINT, parser.remaining_len(), 2)),
+            Vec::with_capacity(elements_capacity(ELEMENTS_HINT.load(Relaxed), parser.remaining_len())),
             Vec::new(),
         ),
         RecursedValue::Object { .. } => (
             Vec::new(),
-            Vec::with_capacity(stack_hint(&MEMBERS_HINT, parser.remaining_len(), 5)),
+            Vec::with_capacity(members_capacity(MEMBERS_HINT.load(Relaxed), parser.remaining_len())),
         ),
     };
     let (mut elements_peak, mut members_peak) = (0, 0);
@@ -400,10 +407,16 @@ fn take_value_recursive<'j, 's>(
             }
             match &current_recursion {
                 RecursedValue::Array { .. } if elements.capacity() == 0 => {
-                    elements.reserve_exact(stack_hint(&ELEMENTS_HINT, parser.remaining_len(), 2));
+                    elements.reserve_exact(elements_capacity(
+                        ELEMENTS_HINT.load(Relaxed),
+                        parser.remaining_len(),
+                    ));
                 }
                 RecursedValue::Object { .. } if members.capacity() == 0 => {
-                    members.reserve_exact(stack_hint(&MEMBERS_HINT, parser.remaining_len(), 5));
+                    members.reserve_exact(members_capacity(
+                        MEMBERS_HINT.load(Relaxed),
+                        parser.remaining_len(),
+                    ));
                 }
                 _ => {}
             }
@@ -784,5 +797,29 @@ fn take_value_skip_recursive(
 
             current_recursion = recursion_stack[current_recursion_depth];
         };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The input bounds are tight: a minimal container gets exactly the capacity it needs, so
+    /// repeated parses of it never reallocate.
+    #[test]
+    fn stack_capacity_bounds_are_tight() {
+        for n in 1..=100 {
+            let array = format!("[{}]", vec!["1"; n].join(","));
+            let mut parser = Parser::new(array.as_bytes());
+            parser.array_first().unwrap().unwrap();
+            assert_eq!(elements_capacity(usize::MAX, parser.remaining_len()), n, "{array}");
+
+            let object = format!("{{{}}}", vec!["\"\":0"; n].join(","));
+            let mut parser = Parser::new(object.as_bytes());
+            let mut tape = Tape::default();
+            parser.object_first::<StringDecoder>(&mut tape).unwrap().unwrap();
+            parser.peek().unwrap();
+            assert_eq!(members_capacity(usize::MAX, parser.remaining_len()), n, "{object}");
+        }
     }
 }

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, OnceLock};
 #[cfg(feature = "num-bigint")]
 use num_bigint::BigInt;
 use smallvec::SmallVec;
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
 use crate::PartialMode;
 use crate::errors::{DEFAULT_RECURSION_LIMIT, JsonError, JsonResult, json_error};
@@ -323,13 +324,23 @@ enum RecursedValue<'s> {
 /// pure overhead, and the outermost array of a big one, which would otherwise be the largest
 /// copy of all.
 #[inline]
-fn take_container<T>(stack: &mut Vec<T>, base: usize) -> Vec<T> {
-    if base == 0 {
-        std::mem::take(stack)
-    } else {
+fn take_container<T>(stack: &mut Vec<T>, base: usize, peak: &mut usize) -> Vec<T> {
+    *peak = (*peak).max(stack.len());
+    if base != 0 {
         stack.split_off(base)
+    } else if stack.capacity() > 2 * stack.len().max(8) {
+        let mut exact = Vec::with_capacity(stack.len());
+        exact.append(stack);
+        exact
+    } else {
+        std::mem::take(stack)
     }
 }
+
+/// The most elements and members the shared stacks held in the last successful parse, so that
+/// the next parse can size them up front; repeated documents of one shape never reallocate.
+static ELEMENTS_HINT: AtomicUsize = AtomicUsize::new(8);
+static MEMBERS_HINT: AtomicUsize = AtomicUsize::new(8);
 
 #[inline(never)] // this is an iterative algo called only from take_value, no point in inlining
 #[allow(clippy::too_many_lines)] // FIXME?
@@ -351,13 +362,13 @@ fn take_value_recursive<'j, 's>(
     // are always the top of the stack, from its `base` up; closing it copies them out into an
     // allocation of exactly the right size. A `Vec` per container has to guess that size instead,
     // and pays a run of reallocations for guessing low.
-    // Only the root container's stack is allocated up front; a document that never opens a
-    // container of the other kind never pays for its stack.
-    let (mut elements, mut members): (Vec<JsonValue<'s>>, Vec<(Cow<'s, str>, JsonValue<'s>)>) = match &current_recursion
-    {
-        RecursedValue::Array { .. } => (Vec::with_capacity(8), Vec::new()),
-        RecursedValue::Object { .. } => (Vec::new(), Vec::with_capacity(8)),
-    };
+    // The stacks are sized from the peaks of the last parse, capped by what the remaining input
+    // could possibly hold: an element needs at least two bytes, a member at least five.
+    let remaining = parser.remaining_len();
+    let mut elements: Vec<JsonValue<'s>> = Vec::with_capacity(ELEMENTS_HINT.load(Relaxed).min(remaining / 2));
+    let mut members: Vec<(Cow<'s, str>, JsonValue<'s>)> =
+        Vec::with_capacity(MEMBERS_HINT.load(Relaxed).min(remaining / 5));
+    let (mut elements_peak, mut members_peak) = (0, 0);
 
     let mut recursion_stack: SmallVec<[RecursedValue; 8]> = SmallVec::new();
     let partial_active = allow_partial.is_active();
@@ -462,7 +473,7 @@ fn take_value_recursive<'j, 's>(
                         }
                     };
 
-                    break JsonValue::Array(Arc::new(take_container(&mut elements, base)));
+                    break JsonValue::Array(Arc::new(take_container(&mut elements, base, &mut elements_peak)));
                 }
             }
             RecursedValue::Object { next_key, .. } => {
@@ -562,7 +573,7 @@ fn take_value_recursive<'j, 's>(
                         }
                     };
 
-                    break JsonValue::Object(Arc::new(take_container(&mut members, base)));
+                    break JsonValue::Object(Arc::new(take_container(&mut members, base, &mut members_peak)));
                 }
             }
         };
@@ -573,6 +584,8 @@ fn take_value_recursive<'j, 's>(
             if let Some(next_recursion) = recursion_stack.pop() {
                 current_recursion = next_recursion;
             } else {
+                ELEMENTS_HINT.store(elements_peak, Relaxed);
+                MEMBERS_HINT.store(members_peak, Relaxed);
                 return Ok(value);
             }
 
@@ -587,7 +600,7 @@ fn take_value_recursive<'j, 's>(
                         Err(e) if !(partial_active && e.allowed_if_partial()) => return Err(e),
                         _ => (),
                     }
-                    JsonValue::Array(Arc::new(take_container(&mut elements, base)))
+                    JsonValue::Array(Arc::new(take_container(&mut elements, base, &mut elements_peak)))
                 }
                 RecursedValue::Object { base, next_key } => {
                     members.push((next_key, value));
@@ -608,7 +621,7 @@ fn take_value_recursive<'j, 's>(
                         _ => (),
                     }
 
-                    JsonValue::Object(Arc::new(take_container(&mut members, base)))
+                    JsonValue::Object(Arc::new(take_container(&mut members, base, &mut members_peak)))
                 }
             }
         };


### PR DESCRIPTION
`take_value_recursive` builds every container on two shared stacks and started them at capacity 8 on every parse, so a 100-element array grew the elements stack four times before `take_container` copied it out. Whether glibc can grow a block in place depends on the heap layout the process started with, which is why `true_array_jiter_value` reads 2.7 µs or 3.1 µs on identical code (0.15% stdev within a run, toolchain and runner identical); the two states' CodSpeed flame graphs differ only in `realloc` taking the in-place path or the `int_malloc` + `memcpy` path.

The stacks are now sized from the peaks the last successful parse reached, capped by what the remaining input could hold (two bytes per element, five per member). A root container that ends up with more than twice the capacity it needs is copied out at its exact size, so a small document parsed after a large one doesn't carry the large one's capacity.

Allocations per warm parse of the bench documents (counted with the `alloc_count` example's allocator):

| document | reallocs before | after | bytes before | after |
|---|---|---|---|---|
| true_array | 4 | 0 | 8424 | 3240 |
| true_object | 5 | 0 | 36264 | 5640 |
| string_array_unique | 7 | 0 | 816040 | 320040 |
| big | 17 | 0 | 8044328 | 7904328 |

Not covered: `string_array_jiter_value_owned` also flips (16.1 vs 17.6 µs), but its flame graphs put the difference in `int_malloc` and `malloc_consolidate` under the 100 per-element `String` allocations, which is glibc's free-list state rather than anything this code controls. `python_parse_x100` and `python_parse_numeric` allocate through pymalloc and are likewise untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm4KCoN9xWsA4HRCL3Lx63

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sizes the shared value stacks from the last parse's peak usage to eliminate repeated reallocations on similar documents.

- Replaces the fixed capacity 8 for elements and members with a hint derived from the last successful parse, capped at 2048 entries and by what the remaining input can hold.
- Only the root container's stack is allocated up front; the other is reserved when its first container opens, so a flat array parsed after a large object never pays for a members stack.
- `take_container` copies out root containers exactly when their capacity is more than double their size, preventing small parses from retaining large capacities.
- The members bound counts the already-consumed opening key (`remaining / 5 + 1`); a test verifies both bounds are tight so minimal containers never reallocate.
- Cuts reallocations and allocation bytes in warm parses (`true_array` 4→0 reallocs, 8424→3240 bytes; `big` 17→0 reallocs).

<sup>Written for commit 077b0c9b3646a153f1fe67ad4ac67cd0145057f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

