### PR TITLE
Add `JsonValueScratch`, reusable stacks for parsing values

### DIFF
--- a/crates/jiter/benches/json_cases.rs
+++ b/crates/jiter/benches/json_cases.rs
@@ -9,7 +9,7 @@ use std::hint::black_box;
 
 use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
 
-use jiter::JsonValue;
+use jiter::{JsonValueScratch, PartialMode};
 use serde_json::Value as SerdeValue;
 
 #[path = "../tests/corpus/mod.rs"]
@@ -19,10 +19,10 @@ use corpus::{TAGS, find_corpus_root, load_cases};
 
 /// Parse every document with jiter, counting the ones that parsed — the malformed documents are
 /// part of the workload, an error is a result like any other.
-fn jiter_value(documents: &[&[u8]]) -> usize {
+fn jiter_value<'j>(scratch: &mut JsonValueScratch<'j>, documents: &[&'j [u8]]) -> usize {
     let mut parsed = 0;
     for json_data in documents {
-        if let Ok(value) = JsonValue::parse(black_box(json_data), false) {
+        if let Ok(value) = scratch.parse(black_box(json_data), false, PartialMode::Off) {
             black_box(&value);
             parsed += 1;
         }
@@ -77,8 +77,9 @@ fn corpus_benches(c: &mut Criterion) {
     for (name, documents) in &groups {
         let bytes: usize = documents.iter().map(|json_data| json_data.len()).sum();
         println!("json_cases_{name}: {} documents, {} bytes", documents.len(), bytes);
+        let mut scratch = JsonValueScratch::new();
         c.bench_function(&format!("json_cases_{name}_jiter_value"), |bench| {
-            bench.iter(|| black_box(jiter_value(documents)));
+            bench.iter(|| black_box(jiter_value(&mut scratch, documents)));
         });
         if !skip_under_codspeed() {
             c.bench_function(&format!("json_cases_{name}_serde_value"), |bench| {

--- a/crates/jiter/benches/main.rs
+++ b/crates/jiter/benches/main.rs
@@ -5,7 +5,7 @@ use std::hint::black_box;
 use std::io::Read;
 use std::path::Path;
 
-use jiter::{Jiter, JsonValue, PartialMode, Peek};
+use jiter::{Jiter, JsonValueScratch, PartialMode, Peek};
 use serde_json::Value;
 
 /// serde_json is the local comparison baseline; CodSpeed tracks jiter's own history, so the serde
@@ -37,9 +37,10 @@ fn jiter_value(path: &str, c: &mut Criterion) {
     let json = read_file(path);
     let json_data = json.as_bytes();
 
+    let mut scratch = JsonValueScratch::new();
     c.bench_function(&title, |bench| {
         bench.iter(|| {
-            let v = JsonValue::parse(black_box(json_data), false).unwrap();
+            let v = scratch.parse(black_box(json_data), false, PartialMode::Off).unwrap();
             black_box(v)
         });
     });
@@ -357,9 +358,12 @@ fn string_array_jiter_value_owned(c: &mut Criterion) {
     let json = read_file("./benches/string_array.json");
     let json_data = json.as_bytes();
 
+    let mut scratch = JsonValueScratch::new();
     c.bench_function("string_array_jiter_value_owned", |bench| {
         bench.iter(|| {
-            let v = JsonValue::parse_owned(black_box(json_data), false, PartialMode::Off).unwrap();
+            let v = scratch
+                .parse_owned(black_box(json_data), false, PartialMode::Off)
+                .unwrap();
             black_box(v)
         });
     });
@@ -369,9 +373,12 @@ fn medium_response_jiter_value_owned(c: &mut Criterion) {
     let json = read_file("./benches/medium_response.json");
     let json_data = json.as_bytes();
 
+    let mut scratch = JsonValueScratch::new();
     c.bench_function("medium_response_jiter_value_owned", |bench| {
         bench.iter(|| {
-            let v = JsonValue::parse_owned(black_box(json_data), false, PartialMode::Off).unwrap();
+            let v = scratch
+                .parse_owned(black_box(json_data), false, PartialMode::Off)
+                .unwrap();
             black_box(v)
         });
     });

--- a/crates/jiter/src/lib.rs
+++ b/crates/jiter/src/lib.rs
@@ -168,7 +168,7 @@ pub use errors::{JiterError, JiterErrorType, JsonError, JsonErrorType, JsonResul
 pub use jiter::{Jiter, JiterResult};
 pub use number_decoder::{NumberAny, NumberFloat, NumberInt};
 pub use parse::Peek;
-pub use value::{JsonArray, JsonObject, JsonValue};
+pub use value::{JsonArray, JsonObject, JsonValue, JsonValueScratch};
 
 #[cfg(feature = "python")]
 pub use py_lossless_float::{FloatMode, LosslessFloat};

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -208,7 +208,8 @@ fn parse_borrowed<'j, const REUSE: bool>(
         allow_partial,
         stacks,
         &|s: StringOutput<'_, 'j>| s.into(),
-    )?;
+    )
+    .inspect_err(|_| stacks.clear())?;
     if !allow_partial.is_active() {
         parser.finish()?;
     }
@@ -233,7 +234,8 @@ fn parse_owned<const REUSE: bool>(
         allow_partial,
         stacks,
         &|s: StringOutput<'_, '_>| Into::<String>::into(s).into(),
-    )?;
+    )
+    .inspect_err(|_| stacks.clear())?;
     parser.finish()?;
     Ok(v)
 }
@@ -383,11 +385,19 @@ enum RecursedValue<'s> {
     Object { base: usize, next_key: Cow<'s, str> },
 }
 
-/// The stacks every container of a document is built on, see [`take_value_recursive`].
+/// The stacks every container of a document is built on, see [`take_value_recursive`]. A
+/// successful parse takes everything off them; a failed one is cleared by its caller.
 #[derive(Default)]
 struct Stacks<'s> {
     elements: Vec<JsonValue<'s>>,
     members: Vec<(Cow<'s, str>, JsonValue<'s>)>,
+}
+
+impl Stacks<'_> {
+    fn clear(&mut self) {
+        self.elements.clear();
+        self.members.clear();
+    }
 }
 
 /// The contents of a container that has just closed, taken off the stack they were built on.
@@ -432,9 +442,6 @@ fn take_value_recursive<'j, 's, const REUSE: bool>(
     // are always the top of the stack, from its `base` up; closing it copies them out into an
     // allocation of exactly the right size. A `Vec` per container has to guess that size instead,
     // and pays a run of reallocations for guessing low.
-    // A failed parse leaves whatever was on the stacks, so start from empty ones.
-    stacks.elements.clear();
-    stacks.members.clear();
     let Stacks { elements, members } = stacks;
 
     let mut recursion_stack: SmallVec<[RecursedValue; 8]> = SmallVec::new();
@@ -822,5 +829,23 @@ fn take_value_skip_recursive(
 
             current_recursion = recursion_stack[current_recursion_depth];
         };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scratch_holds_nothing_after_a_failed_parse() {
+        let mut scratch = JsonValueScratch::new();
+        assert!(
+            scratch
+                .parse_owned(br#"[1, 2, {"a": [3, 4, "#, false, PartialMode::Off)
+                .is_err()
+        );
+        assert!(scratch.0.elements.is_empty());
+        assert!(scratch.0.members.is_empty());
+        assert!(scratch.0.elements.capacity() > 0);
     }
 }

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -848,6 +848,9 @@ fn take_value_skip_recursive(
 mod tests {
     use super::*;
 
+    /// Lives here rather than in `tests/` because it checks the scratch's private buffers: that a
+    /// failed parse leaves nothing on them, and that they keep their capacity. Neither is visible
+    /// through the public API, which only shows that the next parse still succeeds.
     #[test]
     fn scratch_holds_nothing_after_a_failed_parse() {
         let mut scratch = JsonValueScratch::new();

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -101,7 +101,13 @@ impl<'j> JsonValue<'j> {
         allow_inf_nan: bool,
         allow_partial: PartialMode,
     ) -> Result<Self, JsonError> {
-        parse_borrowed::<false>(&mut Stacks::default(), data, allow_inf_nan, allow_partial)
+        parse_borrowed::<false>(
+            &mut Stacks::default(),
+            &mut Tape::default(),
+            data,
+            allow_inf_nan,
+            allow_partial,
+        )
     }
 
     /// Convert a borrowed JSON enum into an owned JSON enum.
@@ -146,21 +152,31 @@ fn value_static(v: JsonValue<'_>) -> JsonValue<'static> {
 impl JsonValue<'static> {
     /// Parse a JSON enum from a byte slice, returning an owned version of the enum.
     pub fn parse_owned(data: &[u8], allow_inf_nan: bool, allow_partial: PartialMode) -> Result<Self, JsonError> {
-        parse_owned::<false>(&mut Stacks::default(), data, allow_inf_nan, allow_partial)
+        parse_owned::<false>(
+            &mut Stacks::default(),
+            &mut Tape::default(),
+            data,
+            allow_inf_nan,
+            allow_partial,
+        )
     }
 }
 
-/// The stacks [`JsonValue`]s are built on, kept between parses.
+/// The buffers [`JsonValue`]s are built with, kept between parses.
 ///
-/// Every container of a document is built on one of two stacks, see [`take_value_recursive`],
-/// which a plain [`JsonValue::parse`] grows from nothing each time. A scratch keeps them at the
-/// size the last document needed, so a run of documents of one shape grows them once, and each
-/// parse allocates only the values it returns.
+/// Every container of a document is built on one of two stacks, and escaped strings are decoded
+/// through a tape, all of which a plain [`JsonValue::parse`] grows from nothing each time. A
+/// scratch keeps them at the largest size any document so far has needed, so a run of documents
+/// of one shape grows them once; after that a parse allocates the values it returns and nothing
+/// else, short of a document nested more than eight containers deep.
 ///
 /// Values parsed on a scratch borrow from the input it was given, so one scratch serves every
 /// document of a lifetime; a `JsonValueScratch<'static>` also parses owned values.
 #[derive(Default)]
-pub struct JsonValueScratch<'j>(Stacks<'j>);
+pub struct JsonValueScratch<'j> {
+    stacks: Stacks<'j>,
+    tape: Tape,
+}
 
 impl<'j> JsonValueScratch<'j> {
     pub fn new() -> Self {
@@ -174,7 +190,7 @@ impl<'j> JsonValueScratch<'j> {
         allow_inf_nan: bool,
         allow_partial: PartialMode,
     ) -> Result<JsonValue<'j>, JsonError> {
-        parse_borrowed::<true>(&mut self.0, data, allow_inf_nan, allow_partial)
+        parse_borrowed::<true>(&mut self.stacks, &mut self.tape, data, allow_inf_nan, allow_partial)
     }
 }
 
@@ -186,23 +202,23 @@ impl JsonValueScratch<'static> {
         allow_inf_nan: bool,
         allow_partial: PartialMode,
     ) -> Result<JsonValue<'static>, JsonError> {
-        parse_owned::<true>(&mut self.0, data, allow_inf_nan, allow_partial)
+        parse_owned::<true>(&mut self.stacks, &mut self.tape, data, allow_inf_nan, allow_partial)
     }
 }
 
 fn parse_borrowed<'j, const REUSE: bool>(
     stacks: &mut Stacks<'j>,
+    tape: &mut Tape,
     data: &'j [u8],
     allow_inf_nan: bool,
     allow_partial: PartialMode,
 ) -> Result<JsonValue<'j>, JsonError> {
     let mut parser = Parser::new(data);
-    let mut tape = Tape::default();
     let peek = parser.peek()?;
     let v = take_value::<REUSE>(
         peek,
         &mut parser,
-        &mut tape,
+        tape,
         DEFAULT_RECURSION_LIMIT,
         allow_inf_nan,
         allow_partial,
@@ -218,17 +234,17 @@ fn parse_borrowed<'j, const REUSE: bool>(
 
 fn parse_owned<const REUSE: bool>(
     stacks: &mut Stacks<'static>,
+    tape: &mut Tape,
     data: &[u8],
     allow_inf_nan: bool,
     allow_partial: PartialMode,
 ) -> Result<JsonValue<'static>, JsonError> {
     let mut parser = Parser::new(data);
-    let mut tape = Tape::default();
     let peek = parser.peek()?;
     let v = take_value::<REUSE>(
         peek,
         &mut parser,
-        &mut tape,
+        tape,
         DEFAULT_RECURSION_LIMIT,
         allow_inf_nan,
         allow_partial,
@@ -406,16 +422,12 @@ impl Stacks<'_> {
 /// has anything on it yet — so the stack itself is the container and can be handed over whole.
 /// That is the whole document for the common single-container case, where copying it out would be
 /// pure overhead, and the outermost array of a big one, which would otherwise be the largest
-/// copy of all. A stack that is `REUSE`d for the next parse is copied out instead, at exactly
-/// its size, and keeps its capacity.
+/// copy of all. A stack that is `REUSE`d for the next parse is split off instead, which copies
+/// its contents into an allocation of exactly their size and leaves it empty with its capacity.
 #[inline]
 fn take_container<T, const REUSE: bool>(stack: &mut Vec<T>, base: usize) -> Vec<T> {
-    if base != 0 {
+    if REUSE || base != 0 {
         stack.split_off(base)
-    } else if REUSE {
-        let mut container = Vec::with_capacity(stack.len());
-        container.append(stack);
-        container
     } else {
         std::mem::take(stack)
     }
@@ -839,13 +851,22 @@ mod tests {
     #[test]
     fn scratch_holds_nothing_after_a_failed_parse() {
         let mut scratch = JsonValueScratch::new();
-        assert!(
+        // a completed member, an element and a decoded escape are on the buffers when this fails
+        let broken: &[u8] = br#"{"a": "escaped\nvalue", "b": [1, 2, {"c": [3, "#;
+        assert!(scratch.parse_owned(broken, false, PartialMode::Off).is_err());
+        assert!(scratch.stacks.elements.is_empty());
+        assert!(scratch.stacks.members.is_empty());
+        assert!(scratch.stacks.elements.capacity() > 0);
+        assert!(scratch.stacks.members.capacity() > 0);
+        assert!(scratch.tape.capacity() > 0);
+
+        assert!(scratch.parse_owned(b"[1] x", false, PartialMode::Off).is_err());
+        assert!(scratch.stacks.elements.is_empty());
+        assert_eq!(
             scratch
-                .parse_owned(br#"[1, 2, {"a": [3, 4, "#, false, PartialMode::Off)
-                .is_err()
+                .parse_owned(br#"["ok\n", {"d": 4}]"#, false, PartialMode::Off)
+                .unwrap(),
+            JsonValue::parse_owned(br#"["ok\n", {"d": 4}]"#, false, PartialMode::Off).unwrap()
         );
-        assert!(scratch.0.elements.is_empty());
-        assert!(scratch.0.members.is_empty());
-        assert!(scratch.0.elements.capacity() > 0);
     }
 }

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -101,22 +101,7 @@ impl<'j> JsonValue<'j> {
         allow_inf_nan: bool,
         allow_partial: PartialMode,
     ) -> Result<Self, JsonError> {
-        let mut parser = Parser::new(data);
-
-        let mut tape = Tape::default();
-        let peek = parser.peek()?;
-        let v = take_value_borrowed(
-            peek,
-            &mut parser,
-            &mut tape,
-            DEFAULT_RECURSION_LIMIT,
-            allow_inf_nan,
-            allow_partial,
-        )?;
-        if !allow_partial.is_active() {
-            parser.finish()?;
-        }
-        Ok(v)
+        parse_borrowed::<false>(&mut Stacks::default(), data, allow_inf_nan, allow_partial)
     }
 
     /// Convert a borrowed JSON enum into an owned JSON enum.
@@ -161,21 +146,96 @@ fn value_static(v: JsonValue<'_>) -> JsonValue<'static> {
 impl JsonValue<'static> {
     /// Parse a JSON enum from a byte slice, returning an owned version of the enum.
     pub fn parse_owned(data: &[u8], allow_inf_nan: bool, allow_partial: PartialMode) -> Result<Self, JsonError> {
-        let mut parser = Parser::new(data);
-
-        let mut tape = Tape::default();
-        let peek = parser.peek()?;
-        let v = take_value_owned(
-            peek,
-            &mut parser,
-            &mut tape,
-            DEFAULT_RECURSION_LIMIT,
-            allow_inf_nan,
-            allow_partial,
-        )?;
-        parser.finish()?;
-        Ok(v)
+        parse_owned::<false>(&mut Stacks::default(), data, allow_inf_nan, allow_partial)
     }
+}
+
+/// The stacks [`JsonValue`]s are built on, kept between parses.
+///
+/// Every container of a document is built on one of two stacks, see [`take_value_recursive`],
+/// which a plain [`JsonValue::parse`] grows from nothing each time. A scratch keeps them at the
+/// size the last document needed, so a run of documents of one shape grows them once, and each
+/// parse allocates only the values it returns.
+///
+/// Values parsed on a scratch borrow from the input it was given, so one scratch serves every
+/// document of a lifetime; a `JsonValueScratch<'static>` also parses owned values.
+#[derive(Default)]
+pub struct JsonValueScratch<'j>(Stacks<'j>);
+
+impl<'j> JsonValueScratch<'j> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Like [`JsonValue::parse_with_config`], on this scratch.
+    pub fn parse(
+        &mut self,
+        data: &'j [u8],
+        allow_inf_nan: bool,
+        allow_partial: PartialMode,
+    ) -> Result<JsonValue<'j>, JsonError> {
+        parse_borrowed::<true>(&mut self.0, data, allow_inf_nan, allow_partial)
+    }
+}
+
+impl JsonValueScratch<'static> {
+    /// Like [`JsonValue::parse_owned`], on this scratch.
+    pub fn parse_owned(
+        &mut self,
+        data: &[u8],
+        allow_inf_nan: bool,
+        allow_partial: PartialMode,
+    ) -> Result<JsonValue<'static>, JsonError> {
+        parse_owned::<true>(&mut self.0, data, allow_inf_nan, allow_partial)
+    }
+}
+
+fn parse_borrowed<'j, const REUSE: bool>(
+    stacks: &mut Stacks<'j>,
+    data: &'j [u8],
+    allow_inf_nan: bool,
+    allow_partial: PartialMode,
+) -> Result<JsonValue<'j>, JsonError> {
+    let mut parser = Parser::new(data);
+    let mut tape = Tape::default();
+    let peek = parser.peek()?;
+    let v = take_value::<REUSE>(
+        peek,
+        &mut parser,
+        &mut tape,
+        DEFAULT_RECURSION_LIMIT,
+        allow_inf_nan,
+        allow_partial,
+        stacks,
+        &|s: StringOutput<'_, 'j>| s.into(),
+    )?;
+    if !allow_partial.is_active() {
+        parser.finish()?;
+    }
+    Ok(v)
+}
+
+fn parse_owned<const REUSE: bool>(
+    stacks: &mut Stacks<'static>,
+    data: &[u8],
+    allow_inf_nan: bool,
+    allow_partial: PartialMode,
+) -> Result<JsonValue<'static>, JsonError> {
+    let mut parser = Parser::new(data);
+    let mut tape = Tape::default();
+    let peek = parser.peek()?;
+    let v = take_value::<REUSE>(
+        peek,
+        &mut parser,
+        &mut tape,
+        DEFAULT_RECURSION_LIMIT,
+        allow_inf_nan,
+        allow_partial,
+        stacks,
+        &|s: StringOutput<'_, '_>| Into::<String>::into(s).into(),
+    )?;
+    parser.finish()?;
+    Ok(v)
 }
 
 pub(crate) fn take_value_borrowed<'j>(
@@ -186,13 +246,14 @@ pub(crate) fn take_value_borrowed<'j>(
     allow_inf_nan: bool,
     allow_partial: PartialMode,
 ) -> JsonResult<JsonValue<'j>> {
-    take_value(
+    take_value::<false>(
         peek,
         parser,
         tape,
         recursion_limit,
         allow_inf_nan,
         allow_partial,
+        &mut Stacks::default(),
         &|s: StringOutput<'_, 'j>| s.into(),
     )
 }
@@ -205,24 +266,27 @@ pub(crate) fn take_value_owned<'j>(
     allow_inf_nan: bool,
     allow_partial: PartialMode,
 ) -> JsonResult<JsonValue<'static>> {
-    take_value(
+    take_value::<false>(
         peek,
         parser,
         tape,
         recursion_limit,
         allow_inf_nan,
         allow_partial,
+        &mut Stacks::default(),
         &|s: StringOutput<'_, 'j>| Into::<String>::into(s).into(),
     )
 }
 
-fn take_value<'j, 's>(
+#[allow(clippy::too_many_arguments)]
+fn take_value<'j, 's, const REUSE: bool>(
     peek: Peek,
     parser: &mut Parser<'j>,
     tape: &mut Tape,
     recursion_limit: u8,
     allow_inf_nan: bool,
     allow_partial: PartialMode,
+    stacks: &mut Stacks<'s>,
     create_cow: &impl Fn(StringOutput<'_, 'j>) -> Cow<'s, str>,
 ) -> JsonResult<JsonValue<'s>> {
     let partial_active = allow_partial.is_active();
@@ -250,7 +314,8 @@ fn take_value<'j, 's>(
                 Err(e) if !(partial_active && e.allowed_if_partial()) => return Err(e),
                 Ok(None) | Err(_) => return Ok(JsonValue::empty_array()),
             };
-            take_value_recursive(
+            stacks.elements.reserve(8);
+            take_value_recursive::<REUSE>(
                 peek_first,
                 RecursedValue::Array { base: 0 },
                 parser,
@@ -258,6 +323,7 @@ fn take_value<'j, 's>(
                 recursion_limit,
                 allow_inf_nan,
                 allow_partial,
+                stacks,
                 create_cow,
             )
         }
@@ -269,8 +335,9 @@ fn take_value<'j, 's>(
                 _ => return Ok(JsonValue::empty_object()),
             };
             let first_key = create_cow(first_key);
+            stacks.members.reserve(8);
             match parser.peek() {
-                Ok(peek) => take_value_recursive(
+                Ok(peek) => take_value_recursive::<REUSE>(
                     peek,
                     RecursedValue::Object {
                         base: 0,
@@ -281,6 +348,7 @@ fn take_value<'j, 's>(
                     recursion_limit,
                     allow_inf_nan,
                     allow_partial,
+                    stacks,
                     create_cow,
                 ),
                 Err(e) if !(partial_active && e.allowed_if_partial()) => Err(e),
@@ -315,26 +383,38 @@ enum RecursedValue<'s> {
     Object { base: usize, next_key: Cow<'s, str> },
 }
 
+/// The stacks every container of a document is built on, see [`take_value_recursive`].
+#[derive(Default)]
+struct Stacks<'s> {
+    elements: Vec<JsonValue<'s>>,
+    members: Vec<(Cow<'s, str>, JsonValue<'s>)>,
+}
+
 /// The contents of a container that has just closed, taken off the stack they were built on.
 ///
 /// `base` of zero means nothing else is on that stack — no enclosing container of the same kind
 /// has anything on it yet — so the stack itself is the container and can be handed over whole.
 /// That is the whole document for the common single-container case, where copying it out would be
 /// pure overhead, and the outermost array of a big one, which would otherwise be the largest
-/// copy of all.
+/// copy of all. A stack that is `REUSE`d for the next parse is copied out instead, at exactly
+/// its size, and keeps its capacity.
 #[inline]
-fn take_container<T>(stack: &mut Vec<T>, base: usize) -> Vec<T> {
-    if base == 0 {
-        std::mem::take(stack)
-    } else {
+fn take_container<T, const REUSE: bool>(stack: &mut Vec<T>, base: usize) -> Vec<T> {
+    if base != 0 {
         stack.split_off(base)
+    } else if REUSE {
+        let mut container = Vec::with_capacity(stack.len());
+        container.append(stack);
+        container
+    } else {
+        std::mem::take(stack)
     }
 }
 
 #[inline(never)] // this is an iterative algo called only from take_value, no point in inlining
 #[allow(clippy::too_many_lines)] // FIXME?
 #[allow(clippy::too_many_arguments)]
-fn take_value_recursive<'j, 's>(
+fn take_value_recursive<'j, 's, const REUSE: bool>(
     mut peek: Peek,
     mut current_recursion: RecursedValue<'s>,
     parser: &mut Parser<'j>,
@@ -342,6 +422,7 @@ fn take_value_recursive<'j, 's>(
     recursion_limit: u8,
     allow_inf_nan: bool,
     allow_partial: PartialMode,
+    stacks: &mut Stacks<'s>,
     create_cow: &impl Fn(StringOutput<'_, 'j>) -> Cow<'s, str>,
 ) -> JsonResult<JsonValue<'s>> {
     let recursion_limit: usize = recursion_limit.into();
@@ -351,13 +432,10 @@ fn take_value_recursive<'j, 's>(
     // are always the top of the stack, from its `base` up; closing it copies them out into an
     // allocation of exactly the right size. A `Vec` per container has to guess that size instead,
     // and pays a run of reallocations for guessing low.
-    // Only the root container's stack is allocated up front; a document that never opens a
-    // container of the other kind never pays for its stack.
-    let (mut elements, mut members): (Vec<JsonValue<'s>>, Vec<(Cow<'s, str>, JsonValue<'s>)>) = match &current_recursion
-    {
-        RecursedValue::Array { .. } => (Vec::with_capacity(8), Vec::new()),
-        RecursedValue::Object { .. } => (Vec::new(), Vec::with_capacity(8)),
-    };
+    // A failed parse leaves whatever was on the stacks, so start from empty ones.
+    stacks.elements.clear();
+    stacks.members.clear();
+    let Stacks { elements, members } = stacks;
 
     let mut recursion_stack: SmallVec<[RecursedValue; 8]> = SmallVec::new();
     let partial_active = allow_partial.is_active();
@@ -462,7 +540,7 @@ fn take_value_recursive<'j, 's>(
                         }
                     };
 
-                    break JsonValue::Array(Arc::new(take_container(&mut elements, base)));
+                    break JsonValue::Array(Arc::new(take_container::<_, REUSE>(elements, base)));
                 }
             }
             RecursedValue::Object { next_key, .. } => {
@@ -562,7 +640,7 @@ fn take_value_recursive<'j, 's>(
                         }
                     };
 
-                    break JsonValue::Object(Arc::new(take_container(&mut members, base)));
+                    break JsonValue::Object(Arc::new(take_container::<_, REUSE>(members, base)));
                 }
             }
         };
@@ -587,7 +665,7 @@ fn take_value_recursive<'j, 's>(
                         Err(e) if !(partial_active && e.allowed_if_partial()) => return Err(e),
                         _ => (),
                     }
-                    JsonValue::Array(Arc::new(take_container(&mut elements, base)))
+                    JsonValue::Array(Arc::new(take_container::<_, REUSE>(elements, base)))
                 }
                 RecursedValue::Object { base, next_key } => {
                     members.push((next_key, value));
@@ -608,7 +686,7 @@ fn take_value_recursive<'j, 's>(
                         _ => (),
                     }
 
-                    JsonValue::Object(Arc::new(take_container(&mut members, base)))
+                    JsonValue::Object(Arc::new(take_container::<_, REUSE>(members, base)))
                 }
             }
         };

--- a/crates/jiter/src/value.rs
+++ b/crates/jiter/src/value.rs
@@ -206,6 +206,9 @@ impl JsonValueScratch<'static> {
     }
 }
 
+/// Parse a whole document into a value borrowing from `data`, on the given buffers. Under
+/// `REUSE` the stacks are left empty with their capacity for the next parse, otherwise the root
+/// container takes its stack over.
 fn parse_borrowed<'j, const REUSE: bool>(
     stacks: &mut Stacks<'j>,
     tape: &mut Tape,
@@ -232,6 +235,7 @@ fn parse_borrowed<'j, const REUSE: bool>(
     Ok(v)
 }
 
+/// [`parse_borrowed`] for an owned value: strings are copied out of `data` rather than borrowed.
 fn parse_owned<const REUSE: bool>(
     stacks: &mut Stacks<'static>,
     tape: &mut Tape,
@@ -256,6 +260,8 @@ fn parse_owned<const REUSE: bool>(
     Ok(v)
 }
 
+/// Take the next value from `parser` as a value borrowing from its input; the entry point for
+/// [`Jiter`](crate::Jiter), which has its own parser and tape.
 pub(crate) fn take_value_borrowed<'j>(
     peek: Peek,
     parser: &mut Parser<'j>,
@@ -276,6 +282,7 @@ pub(crate) fn take_value_borrowed<'j>(
     )
 }
 
+/// [`take_value_borrowed`] for an owned value: strings are copied out of the input.
 pub(crate) fn take_value_owned<'j>(
     peek: Peek,
     parser: &mut Parser<'j>,
@@ -296,6 +303,9 @@ pub(crate) fn take_value_owned<'j>(
     )
 }
 
+/// Take the next value from `parser`, `create_cow` deciding whether its strings are borrowed
+/// or copied. Scalars are returned directly; a container hands over to
+/// [`take_value_recursive`], with the root's stack reserved first.
 #[allow(clippy::too_many_arguments)]
 fn take_value<'j, 's, const REUSE: bool>(
     peek: Peek,

--- a/crates/jiter/tests/main.rs
+++ b/crates/jiter/tests/main.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use num_bigint::BigInt;
 
 use jiter::{
-    Jiter, JiterErrorType, JiterResult, JsonErrorType, JsonObject, JsonType, JsonValue, LinePosition, NumberAny,
-    NumberFloat, NumberInt, PartialMode, Peek,
+    Jiter, JiterErrorType, JiterResult, JsonErrorType, JsonObject, JsonType, JsonValue, JsonValueScratch, LinePosition,
+    NumberAny, NumberFloat, NumberInt, PartialMode, Peek,
 };
 
 fn json_vec(jiter: &mut Jiter, peek: Option<Peek>) -> JiterResult<Vec<String>> {
@@ -2072,4 +2072,55 @@ fn test_many_floats() {
             rand() % 1_000_000_000_000_000_000
         ));
     }
+}
+
+#[test]
+fn test_scratch_reuse() {
+    let documents: [&[u8]; 5] = [
+        br#"[true, false, null, 1, 2.5, "x", [1, [2, [3]]], {"a": {"b": [1, {"c": 2}]}}]"#,
+        br#"{"person": {"name": "x", "tags": ["a", "b"]}, "count": 3}"#,
+        b"[]",
+        b"{}",
+        br#""just a string""#,
+    ];
+    let mut scratch = JsonValueScratch::new();
+    for _ in 0..3 {
+        for json_data in documents {
+            let expected = JsonValue::parse(json_data, false).unwrap();
+            assert_eq!(scratch.parse(json_data, false, PartialMode::Off).unwrap(), expected);
+        }
+    }
+}
+
+#[test]
+fn test_scratch_owned() {
+    let mut scratch = JsonValueScratch::new();
+    let value = {
+        let s = r#"  { "int": 1, "const": true, "float": 1.2, "array": [1, false, null]}"#.to_string();
+        scratch.parse_owned(s.as_bytes(), false, PartialMode::Off).unwrap()
+    };
+    assert_eq!(value, value_owned());
+    let again = scratch
+        .parse_owned(br#"[{"k": "v"}, {"k": "w"}]"#, false, PartialMode::Off)
+        .unwrap();
+    assert_eq!(
+        again,
+        JsonValue::parse_owned(br#"[{"k": "v"}, {"k": "w"}]"#, false, PartialMode::Off).unwrap()
+    );
+}
+
+#[test]
+fn test_scratch_after_error() {
+    let mut scratch = JsonValueScratch::new();
+    let broken: &[u8] = br#"[1, 2, {"a": [3, 4, "#;
+    assert!(scratch.parse(broken, false, PartialMode::Off).is_err());
+    let json_data: &[u8] = br#"[5, {"b": 6}]"#;
+    assert_eq!(
+        scratch.parse(json_data, false, PartialMode::Off).unwrap(),
+        JsonValue::parse(json_data, false).unwrap()
+    );
+    assert_eq!(
+        scratch.parse(broken, false, PartialMode::On).unwrap(),
+        JsonValue::parse_with_config(broken, false, PartialMode::On).unwrap()
+    );
 }

--- a/crates/jiter/tests/main.rs
+++ b/crates/jiter/tests/main.rs
@@ -2112,9 +2112,11 @@ fn test_scratch_owned() {
 #[test]
 fn test_scratch_after_error() {
     let mut scratch = JsonValueScratch::new();
-    let broken: &[u8] = br#"[1, 2, {"a": [3, 4, "#;
+    let broken: &[u8] = br#"{"a": "escaped\nvalue", "b": [1, 2, {"c": [3, "#;
     assert!(scratch.parse(broken, false, PartialMode::Off).is_err());
-    let json_data: &[u8] = br#"[5, {"b": 6}]"#;
+    let trailing: &[u8] = br#"[1, "two\n"] x"#;
+    assert!(scratch.parse(trailing, false, PartialMode::Off).is_err());
+    let json_data: &[u8] = br#"[5, {"b": "six\n"}]"#;
     assert_eq!(
         scratch.parse(json_data, false, PartialMode::Off).unwrap(),
         JsonValue::parse(json_data, false).unwrap()


### PR DESCRIPTION
mostly to make benchmarks less variable.

---

`take_value_recursive` builds every container of a document on two shared stacks, which `JsonValue::parse` grows from nothing on every call; a 100-element array reallocates the elements stack four times before its contents are copied out. Whether glibc can grow a block in place depends on the heap layout the process started with, which is why `true_array_jiter_value` reads 2.7 µs or 3.1 µs on identical code (0.15% stdev within a run, toolchain and runner identical); the two states' CodSpeed flame graphs differ only in `realloc` taking the in-place path or the `int_malloc` + `memcpy` path.

This adds `JsonValueScratch`, which owns the stacks and keeps them between parses:

```rust
let mut scratch = JsonValueScratch::new();
for json_data in documents {
    let value = scratch.parse(json_data, false, PartialMode::Off)?;
}
```

A run of documents of one shape grows the stacks once, and each parse allocates only the values it returns; the root container is copied out at exactly its size rather than taking the stack. Values borrow from the input, so one scratch serves every document of a lifetime, and a `JsonValueScratch<'static>` has `parse_owned`. `JsonValue::parse` and `parse_owned` are unchanged and run on fresh stacks, so there is no global state and nothing to guess; this supersedes #291.

The value benchmarks (`*_jiter_value`, `*_jiter_value_owned`, `json_cases_*_jiter_value`) parse on a scratch, so they measure the parser rather than the heap layout. CodSpeed will report those as changed once. Allocations per parse of the bench documents, plain `JsonValue::parse` versus a warm scratch:

| document | reallocs | bytes |
|---|---|---|
| true_array | 4 → 0 | 7976 → 3240 |
| true_object | 4 → 0 | 13928 → 5640 |
| string_array_unique | 11 → 0 | 1048360 → 320040 |
| big | 15 → 0 | 8.0 MB → 7.9 MB |

Not covered: `string_array_jiter_value_owned` also flips (16.1 vs 17.6 µs), but its flame graphs put the difference under the 100 per-element `String` allocations, glibc free-list state rather than anything the parser controls; `python_parse_x100` and `python_parse_numeric` allocate through pymalloc and are likewise untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm4KCoN9xWsA4HRCL3Lx63


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `JsonValueScratch`, a reusable buffer type that keeps the internal stacks and string-decoding tape across parses, cutting allocations and making parse performance independent of heap layout.

- `JsonValue::parse` and `parse_owned` unchanged; they still use fresh buffers.
- `JsonValueScratch::parse` returns values borrowed from the input; `parse_owned` on a `'static` scratch returns owned values.
- Failed parses clear the scratch immediately, so half-built containers don't hold their strings alive.
- Benchmarks now parse on a scratch so they measure parser rather than heap behavior.
- Tests cover reuse, owned parsing, recovery after errors, and that failed parses leave the scratch buffers empty but retaining capacity.

<sup>Written for commit d8cc5f5621c800ece13fb3229daa22f5a00c58e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



