### PR TITLE
Return CPython's singletons for empty and single-character strings

### DIFF
--- a/crates/jiter-python/tests/test_jiter.py
+++ b/crates/jiter-python/tests/test_jiter.py
@@ -397,6 +397,21 @@ def test_against_json():
 
 
 @pytest.mark.skipif(
+    sys.implementation.name != 'cpython', reason='singletons are a CPython detail'
+)
+def test_short_strings_are_singletons():
+    """CPython interns the empty string and every single Latin-1 character."""
+    for s in ['', 'a', ' ', '\x7f']:
+        data = json.dumps([s, {s: s}]).encode()
+        for cache_mode in (True, False):
+            parsed, obj = jiter.from_json(data, cache_mode=cache_mode)
+            assert parsed is s
+            key, value = next(iter(obj.items()))
+            assert key is s
+            assert value is s
+
+
+@pytest.mark.skipif(
     sys.platform == 'emscripten', reason='threads not supported on pyodide'
 )
 def test_multithreaded_parsing():

--- a/crates/jiter/src/py_string_cache.rs
+++ b/crates/jiter/src/py_string_cache.rs
@@ -330,6 +330,9 @@ pub unsafe fn pystring_ascii_new<'py>(py: Python<'py>, s: &str) -> Bound<'py, Py
     unsafe {
         #[cfg(not(any(PyPy, GraalPy, Py_LIMITED_API)))]
         {
+            if s.len() <= 1 {
+                return PyString::new(py, s);
+            }
             // SAFETY: `PyUnicode_New` returns a new owned reference or null. Converting it to a
             // `Bound` immediately ensures an allocation failure is handled before dereferencing it.
             let py_string = Bound::from_owned_ptr(py, pyo3::ffi::PyUnicode_New(s.len() as isize, 127));


### PR DESCRIPTION
CPython statically allocates the empty string and all 256 single Latin-1 characters, and `PyUnicode_FromStringAndSize` returns those singletons for a 0 or 1 byte input. Our ASCII fast constructor always called `PyUnicode_New`, which allocates a fresh object every time (and, for the empty string, wrote a terminator into the shared empty singleton). ujson and orjson both take the singleton path for these; this does the same, picking up the partial implementation from #280.

A one-byte string is always ASCII, and strings shorter than two bytes already skip the cache, so a single check in `pystring_ascii_new` covers both cache modes.

Local numbers from `bench.py --case array_short_arrays` (10k copies of `["a", "b", "c", "d"]`), arm64:

| package | before µs | after µs |
|---|---|---|
| jiter | 968 | 658 |
| jiter-cache | 1008 | 689 |
| ujson | 665 | 687 |
| orjson | 890 | 900 |

Other cases are unchanged, since none of them contain strings that short. A test asserts the parsed value, key and dict value are identical to the interpreter's singleton in both cache modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm4KCoN9xWsA4HRCL3Lx63


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns CPython's singleton strings for empty and single-character strings in the ASCII fast path, avoiding a fresh allocation and preventing writes to the shared empty string singleton.

- Uses `PyString::new` for strings of length 0 or 1, which returns CPython's statically allocated singletons.
- The check applies to both cache modes because strings shorter than two bytes already skip the cache.
- Speeds up parsing of arrays of short strings (e.g., `["a", "b", "c", "d"]`) by ~30% in local benchmarks; other cases are unaffected.
- Adds a test that parsed strings, keys, and values are the same singleton objects as CPython's, in both cache modes.

<sup>Written for commit 165d6736e8bc5a876d26196317c168eea0698658. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

