### PR TITLE
release: 0.17.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,12 @@ repos:
         types: [python]
         language: system
         pass_filenames: false
+      - id: format-md
+        name: Format markdown
+        entry: make format-md
+        types: [markdown]
+        language: system
+        pass_filenames: false
       - id: check-without-num-bigint
         name: Check without num-bigint feature
         entry: cargo check --no-default-features --package jiter

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiter"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash",
  "bitvec",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "jiter-python"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "jiter",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 license = "MIT"
 keywords = ["JSON", "parsing", "deserialization", "iter"]

--- a/Makefile
+++ b/Makefile
@@ -20,23 +20,23 @@ lint:
 
 .PHONY: lint-python
 lint-python: .uv
-	uv run ruff check $(python_sources)
-	uv run ruff format --check $(python_sources)
+	uv run --group linting ruff check $(python_sources)
+	uv run --group linting ruff format --check $(python_sources)
 
 .PHONY: format-python
 format-python: .uv
-	uv run ruff format $(python_sources)
-	uv run ruff check --fix --fix-only $(python_sources)
+	uv run --group linting ruff format $(python_sources)
+	uv run --group linting ruff check --fix --fix-only $(python_sources)
 
 MD_FILES := $(shell git ls-files '*.md')
 
 .PHONY: format-md
 format-md: .uv
-	uv run mdformat $(MD_FILES)
+	uv run --group linting mdformat $(MD_FILES)
 
 .PHONY: lint-md
 lint-md: .uv
-	uv run mdformat --check $(MD_FILES)
+	uv run --group linting mdformat --check $(MD_FILES)
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,16 @@ format-python: .uv
 	uv run ruff format $(python_sources)
 	uv run ruff check --fix --fix-only $(python_sources)
 
+MD_FILES := $(shell git ls-files '*.md')
+
+.PHONY: format-md
+format-md: .uv
+	uv run mdformat $(MD_FILES)
+
+.PHONY: lint-md
+lint-md: .uv
+	uv run mdformat --check $(MD_FILES)
+
 .PHONY: test
 test:
 	cargo test

--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,13 @@ format-python: .uv
 	uv run --group linting ruff format $(python_sources)
 	uv run --group linting ruff check --fix --fix-only $(python_sources)
 
-MD_FILES := $(shell git ls-files '*.md')
-
 .PHONY: format-md
 format-md: .uv
-	uv run --group linting mdformat $(MD_FILES)
+	uv run --group linting mdformat --exclude '**/.*/**' --exclude '**/target/**' README.md crates
 
 .PHONY: lint-md
 lint-md: .uv
-	uv run --group linting mdformat --check $(MD_FILES)
+	uv run --group linting mdformat --check --exclude '**/.*/**' --exclude '**/target/**' README.md crates
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Fast iterable JSON parser.
 Documentation is available at [docs.rs/jiter](https://docs.rs/jiter).
 
 jiter has three interfaces:
-* `JsonValue` an enum representing JSON data
-* `Jiter` an iterator over JSON data
-* `PythonParse` which parses a JSON string into a Python object
+
+- `JsonValue` an enum representing JSON data
+- `Jiter` an iterator over JSON data
+- `PythonParse` which parses a JSON string into a Python object
 
 ## JsonValue Example
 
@@ -95,40 +96,43 @@ to a string.
 
 For more details, see [the benchmarks](https://github.com/pydantic/jiter/tree/main/crates/jiter/benches).
 
-| benchmark | `jiter` iter | `jiter` value | `serde` value | `serde`/`jiter` |
-| --- | ---: | ---: | ---: | ---: |
-| **strings** | | | | |
-| x100 | 10ns | 11ns | 37ns | 3.2x |
-| sentence | 234ns | 278ns | 296ns | 1.1x |
-| unicode | 291ns | 307ns | 322ns | 1.1x |
-| unicode_dense | 150ns | 152ns | 177ns | 1.2x |
-| string_array | 470ns | 954ns | 3.0µs | 3.2x |
-| json_cases_strings | - | 18.85ms | 59.62ms | 3.2x |
-| json_cases_escapes | - | 1.70ms | 2.52ms | 1.5x |
-| json_cases_non-ascii | - | 830.0µs | 1.16ms | 1.4x |
-| **numbers** | | | | |
-| short_numbers | - | 9.1µs | 37.6µs | 4.1x |
-| floats_array | 15.6µs | 23.9µs | 117.9µs | 4.9x |
-| bigints_array | 10.4µs | 16.4µs | 69.4µs | 4.2x |
-| massive_ints_array | 74.1µs | 79.2µs | 279.9µs | 3.5x |
-| big | 3.04ms | 4.37ms | 20.73ms | 4.7x |
-| json_cases_numbers | - | 11.29ms | 54.53ms | 4.8x |
-| json_cases_ints | - | 11.13ms | 50.96ms | 4.6x |
-| json_cases_floats | - | 3.43ms | 15.90ms | 4.6x |
-| **constants** | | | | |
-| true_array | 196ns | 637ns | 1.1µs | 1.7x |
-| true_object | 2.2µs | 1.5µs | 5.7µs | 3.8x |
-| json_cases_constants | - | 27.4µs | 58.7µs | 2.1x |
-| **documents** | | | | |
-| pass1 | - | 2.2µs | 5.4µs | 2.5x |
-| pass2 | 314ns | 759ns | 574ns | 0.8x |
-| medium_response | - | 2.4µs | 6.9µs | 2.9x |
-| json_cases_all | - | 26.74ms | 90.50ms | 3.4x |
-| json_cases_arrays | - | 11.13ms | 47.00ms | 4.2x |
-| json_cases_objects | - | 17.17ms | 53.85ms | 3.1x |
-| json_cases_deep | - | 5.81ms | 12.97ms | 2.2x |
-| json_cases_whitespace | - | 6.90ms | 16.51ms | 2.4x |
-| json_cases_error | - | 2.73ms | 11.91ms | 4.4x |
+| benchmark               | `jiter` iter | `jiter` value | `serde` value | `serde`/`jiter` |
+| ----------------------- | -----------: | ------------: | ------------: | --------------: |
+| **strings**             |              |               |               |                 |
+| x100                    |          8ns |           9ns |          40ns |            4.4x |
+| sentence                |        232ns |         124ns |         293ns |            2.4x |
+| unicode                 |        268ns |         159ns |         308ns |            1.9x |
+| unicode_dense           |        152ns |         152ns |         177ns |            1.2x |
+| string_array            |        466ns |         751ns |         3.0µs |            4.0x |
+| pass2                   |        304ns |         785ns |         576ns |            0.7x |
+| json_cases_strings      |            - |       14.92ms |       58.85ms |            3.9x |
+| json_cases_escapes      |            - |        1.62ms |        2.44ms |            1.5x |
+| json_cases_non-ascii    |            - |       715.5µs |       995.3µs |            1.4x |
+| **numbers**             |              |               |               |                 |
+| short_numbers           |            - |        10.9µs |        37.6µs |            3.4x |
+| floats_array            |       15.2µs |        19.2µs |       117.2µs |            6.1x |
+| doubles_array           |       13.2µs |        17.6µs |       110.9µs |            6.3x |
+| short_floats            |        9.7µs |        12.6µs |        46.6µs |            3.7x |
+| long_significand_floats |       12.1µs |        13.9µs |        94.7µs |            6.8x |
+| bigints_array           |       12.2µs |        12.5µs |        69.3µs |            5.6x |
+| massive_ints_array      |       73.2µs |        77.9µs |       284.9µs |            3.7x |
+| big                     |       2.93ms |        3.96ms |       20.32ms |            5.1x |
+| json_cases_numbers      |            - |        7.81ms |       50.42ms |            6.5x |
+| json_cases_ints         |            - |        7.82ms |       50.27ms |            6.4x |
+| json_cases_floats       |            - |        3.04ms |       17.68ms |            5.8x |
+| **constants**           |              |               |               |                 |
+| true_array              |        194ns |         477ns |         1.1µs |            2.3x |
+| true_object             |        2.4µs |         1.4µs |         6.0µs |            4.2x |
+| json_cases_constants    |            - |        25.6µs |        66.3µs |            2.6x |
+| **documents**           |              |               |               |                 |
+| pass1                   |            - |         1.8µs |         5.3µs |            3.0x |
+| medium_response         |            - |         2.2µs |         6.8µs |            3.1x |
+| json_cases_all          |            - |       22.15ms |       90.38ms |            4.1x |
+| json_cases_arrays       |            - |       10.78ms |       45.96ms |            4.3x |
+| json_cases_objects      |            - |       12.98ms |       53.66ms |            4.1x |
+| json_cases_deep         |            - |        4.63ms |       12.83ms |            2.8x |
+| json_cases_whitespace   |            - |        6.24ms |       16.58ms |            2.7x |
+| json_cases_error        |            - |        2.38ms |       11.87ms |            5.0x |
 
 ## Part of the Pydantic Stack
 

--- a/crates/jiter-python/README.md
+++ b/crates/jiter-python/README.md
@@ -58,6 +58,7 @@ def cache_usage() -> int:
     """
 
 ```
+
 ## Examples
 
 The main function provided by Jiter is `from_json()`, which accepts a bytes object containing JSON and returns a Python dictionary, list or other value.

--- a/crates/jiter-python/pyproject.toml
+++ b/crates/jiter-python/pyproject.toml
@@ -41,5 +41,5 @@ dynamic = ["version"]
 module-name = "jiter"
 bindings = "pyo3"
 features = []
-editable-profile = 'dev'
+editable-profile = "dev"
 pgo-command = "python bench.py jiter jiter-cache"

--- a/crates/jiter/benches/criterion_table.py
+++ b/crates/jiter/benches/criterion_table.py
@@ -39,6 +39,9 @@ GROUPS: list[tuple[str, list[str]]] = [
         [
             'short_numbers',
             'floats_array',
+            'doubles_array',
+            'short_floats',
+            'long_significand_floats',
             'bigints_array',
             'massive_ints_array',
             # despite the name, big.json is 1000 arrays of ints and floats with no strings,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ bench = [
 ]
 linting = [
     "ruff",
-    # markdown formatting (`make format-md`); style is in .mdformat.toml
+    # markdown formatting, `make format-md`
     "mdformat",
     "mdformat-tables",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ bench = [
 ]
 linting = [
     "ruff",
+    # markdown formatting (`make format-md`); style is in .mdformat.toml
+    "mdformat",
+    "mdformat-tables",
 ]
 pyodide-build = [
     "pyodide-build",

--- a/uv.lock
+++ b/uv.lock
@@ -420,6 +420,8 @@ dev = [
     { name = "pytest-pretty" },
 ]
 linting = [
+    { name = "mdformat" },
+    { name = "mdformat-tables" },
     { name = "ruff" },
 ]
 pyodide-build = [
@@ -440,7 +442,11 @@ dev = [
     { name = "pytest" },
     { name = "pytest-pretty" },
 ]
-linting = [{ name = "ruff" }]
+linting = [
+    { name = "mdformat" },
+    { name = "mdformat-tables" },
+    { name = "ruff" },
+]
 pyodide-build = [{ name = "pyodide-build" }]
 
 [[package]]
@@ -466,14 +472,14 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
 ]
 
 [[package]]
@@ -498,6 +504,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/70/d8/202a7b4d75a51f20f84ec9ce3b7345b12b822207072164e2b1c6ef665125/maturin-1.15.0-py3-none-win32.whl", hash = "sha256:da649988be98e87e009e51b1bf0d301b6a301bc0cecbdd60d40d8ba60748d1ca", size = 8928744, upload-time = "2026-08-24T12:11:16.269Z" },
     { url = "https://files.pythonhosted.org/packages/40/dc/4e90da594986ba78dd3bc8a5921ecdcdb11085b22b02a412caab3b225601/maturin-1.15.0-py3-none-win_amd64.whl", hash = "sha256:552c2be4afd43fe8d5c9f3ec8d4c4756d973b8dcbe94c14084390301f50243e1", size = 10335085, upload-time = "2026-08-24T12:11:18.326Z" },
     { url = "https://files.pythonhosted.org/packages/8b/10/15d4314edf130955edf2dc237aa393a8a7c10f2b9b57b89fa2f61f915659/maturin-1.15.0-py3-none-win_arm64.whl", hash = "sha256:c7dc0c66c78d3debdd9c5aa807e861fbcbf07f3505d34b125df74c03986b0f48", size = 9713795, upload-time = "2026-08-24T12:11:20.83Z" },
+]
+
+[[package]]
+name = "mdformat"
+version = "0.7.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/eb/b5cbf2484411af039a3d4aeb53a5160fae25dd8c84af6a4243bc2f3fedb3/mdformat-0.7.22.tar.gz", hash = "sha256:eef84fa8f233d3162734683c2a8a6222227a229b9206872e6139658d99acb1ea", size = 34610, upload-time = "2025-01-30T18:00:51.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/6f/94a7344f6d634fe3563bea8b33bccedee37f2726f7807e9a58440dc91627/mdformat-0.7.22-py3-none-any.whl", hash = "sha256:61122637c9e1d9be1329054f3fa216559f0d1f722b7919b060a8c2a4ae1850e5", size = 34447, upload-time = "2025-01-30T18:00:48.708Z" },
+]
+
+[[package]]
+name = "mdformat-tables"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/fc/995ba209096bdebdeb8893d507c7b32b7e07d9a9f2cdc2ec07529947794b/mdformat_tables-1.0.0.tar.gz", hash = "sha256:a57db1ac17c4a125da794ef45539904bb8a9592e80557d525e1f169c96daa2c8", size = 6106, upload-time = "2024-08-23T23:41:33.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/37/d78e37d14323da3f607cd1af7daf262cb87fe614a245c15ad03bb03a2706/mdformat_tables-1.0.0-py3-none-any.whl", hash = "sha256:94cd86126141b2adc3b04c08d1441eb1272b36c39146bab078249a41c7240a9a", size = 5104, upload-time = "2024-08-23T23:41:31.863Z" },
 ]
 
 [[package]]
@@ -1336,6 +1368,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783", size = 4558820, upload-time = "2026-06-16T16:23:56.963Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/57/ed58088fafdf4c55a0ad6bde846502567645424d7ebf325230b9237f4085/wcwidth-0.8.3.tar.gz", hash = "sha256:d128512515fbf4612e0ff21fd6380399210318b7b54a9af59dff8454cf9730eb", size = 1458450, upload-time = "2026-08-28T18:10:06.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/0e/57f6bb3024a597b2e8ec4aee710ffe62ddc95af2e2bb1ee7a7abdc22c68c/wcwidth-0.8.3-py3-none-any.whl", hash = "sha256:d5b73dba6158a595ec9370350e7f2637bcac8d6c5e4fde34f30fcffb6103a5e4", size = 331669, upload-time = "2026-08-28T18:10:04.909Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Bump the version to 0.17.0 (`Cargo.toml`, `Cargo.lock`).
- Regenerate the README benchmark table with `make bench-table` at `JITER_BENCH_SEED=0` and the json-cases corpus at the CI-pinned commit. Every row has moved since the last refresh, from the SIMD string scanning, the digit-run number decoder, the shared container stacks and the string cache changes; `json_cases_all` goes from 26.7ms to 22.2ms.
- Register `doubles_array`, `short_floats` and `long_significand_floats` (added in #283) in the table script's numbers group, so they stop falling into the "other" bucket.
- Add mdformat to the `linting` group with `make format-md` / `make lint-md` and a pre-commit hook that runs the formatter. mdformat's defaults are the style we want, so there's no config file. This is what padded and aligned the table's columns; the only other change it made is `*` to `-` bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm4KCoN9xWsA4HRCL3Lx63

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the version to 0.17.0 and regenerates the benchmark table, which shows broad gains from the SIMD string scanning, digit-run number decoder, shared container stacks, and string cache changes — `json_cases_all` drops from 26.7ms to 22.2ms.

- Registers `doubles_array`, `short_floats`, and `long_significand_floats` (added in #283) in the table script's numbers group so they no longer fall into the "other" bucket.
- Adds `mdformat` and `mdformat-tables` to the linting group, exposed via `make format-md` / `make lint-md` and a pre-commit hook; the formatter realigned the table columns and converted `*` bullets to `-`.
- The markdown recipes target `README.md` and `crates` explicitly (excluding hidden and `target` dirs) since mdformat ignores `.gitignore`.
- Ruff and markdown recipes run with `uv run --group linting` so they work in fresh checkouts where `uv` syncs only the default dev group.

<sup>Written for commit 6782b5d61102cdd7beab08307f5e5498295ec40d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

