### PR TITLE
Reserve the decode tape once per escaped string

### DIFF
--- a/crates/jiter/src/string_decoder.rs
+++ b/crates/jiter/src/string_decoder.rs
@@ -134,6 +134,10 @@ where
     }
 }
 
+/// The decoded string is never longer than the raw one, so the rest of the input bounds the tape;
+/// reserving that much up to this cap makes a short escaped string a single allocation.
+const MAX_TAPE_RESERVE: usize = 8192;
+
 fn decode_to_tape<'t, 'j>(
     data: &'j [u8],
     mut index: usize,
@@ -143,6 +147,7 @@ fn decode_to_tape<'t, 'j>(
     allow_partial: bool,
 ) -> JsonResult<(StringOutput<'t, 'j>, usize)> {
     tape.clear();
+    tape.reserve((data.len() - start).min(MAX_TAPE_RESERVE));
     let mut chunk_start = start;
     loop {
         // on_backslash

--- a/crates/jiter/src/string_decoder.rs
+++ b/crates/jiter/src/string_decoder.rs
@@ -134,8 +134,9 @@ where
     }
 }
 
-/// The decoded string is never longer than the raw one, so the rest of the input bounds the tape;
-/// reserving that much up to this cap makes a short escaped string a single allocation.
+/// Cap on the tape capacity reserved when a string turns out to contain escapes. The rest of the
+/// input bounds the decoded length, so reserving it makes a short string a single allocation; the
+/// cap stops a short string near the start of a large document reserving the whole document.
 const MAX_TAPE_RESERVE: usize = 8192;
 
 fn decode_to_tape<'t, 'j>(


### PR DESCRIPTION
`unicode_jiter_iter` and `sentence_jiter_iter` flip by up to 15% between commits that don't touch string decoding. The CodSpeed flamegraphs show why: decoding a string with escapes appends to the tape chunk by chunk, so a fresh parser's tape grows through four reallocs for a few-hundred-byte string, and under glibc that is 36–42% of the benchmark. Whether each realloc moves the buffer depends on the heap state, so a change anywhere in the binary can flip the benchmark between its two states, the same mechanism as the `true_array` flips fixed by #269.

The decoded string is never longer than the raw one, so the remaining input bounds the tape. Reserve that on entering escaped decoding, capped at 8 KB so a short string at the start of a large document doesn't reserve the whole document; longer strings still grow amortized from there. A short escaped string is now a single allocation (1 alloc + 4 reallocs before, 1 alloc after), and a reused tape is untouched since the reservation is a no-op once capacity is there.

| bench | x86_64 glibc before | after | arm64 macOS before | after |
|---|---|---|---|---|
| sentence_jiter_iter | 256 ns | 125 ns | 231 ns | 124 ns |
| unicode_jiter_iter | 317 ns | 165 ns | 268 ns | 157 ns |

The value benchmarks and every benchmark without escapes are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm4KCoN9xWsA4HRCL3Lx63

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserves the decode tape once per escaped string, eliminating up to four reallocs and the 15% benchmark flips that stemmed from heap-state-dependent realloc moves.

**Performance**  
- `sentence_jiter_iter`: 256→125 ns on x86_64 glibc, 231→124 ns on arm64 macOS.  
- `unicode_jiter_iter`: 317→165 ns on x86_64 glibc, 268→157 ns on arm64 macOS.  
- Non-escaped strings and value benchmarks are unchanged.

<sup>Written for commit 7edb809d7517898dcf53e1c0aa07e9d136791668. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

