### PR TITLE
Replace the x100 Python benchmarks with a thousand long strings

### DIFF
--- a/crates/jiter/benches/python.rs
+++ b/crates/jiter/benches/python.rs
@@ -95,12 +95,41 @@ fn python_parse_string_array(c: &mut Criterion) {
     python_parse_file("./benches/string_array.json", c, StringCacheMode::All);
 }
 
-fn python_parse_x100_not_cached(c: &mut Criterion) {
-    python_parse_file("./benches/x100.json", c, StringCacheMode::None);
+/// A thousand ASCII strings of 64 to 2000 characters, too long for the string cache, so one
+/// variant covers both cache modes. Built here so the repository doesn't carry a megabyte of filler.
+fn long_strings_json() -> Vec<u8> {
+    let mut state: u64 = 0x2545_f491_4f6c_dd1d;
+    let mut next = move || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    let filler = b"the quick brown fox jumps over the lazy dog 0123456789 ";
+    let mut json = Vec::with_capacity(1_100_000);
+    json.push(b'[');
+    for i in 0..1000 {
+        if i > 0 {
+            json.push(b',');
+        }
+        json.push(b'"');
+        let len = 64 + (next() % (2000 - 64 + 1)) as usize;
+        let offset = (next() % filler.len() as u64) as usize;
+        json.extend(filler.iter().cycle().skip(offset).take(len));
+        json.push(b'"');
+    }
+    json.push(b']');
+    json
 }
 
-fn python_parse_x100(c: &mut Criterion) {
-    python_parse_file("./benches/x100.json", c, StringCacheMode::All);
+fn python_parse_long_strings(c: &mut Criterion) {
+    let json_data = long_strings_json();
+    Python::attach(|py| {
+        cache_clear();
+        c.bench_function("python_parse_long_strings", |bench| {
+            bench.iter(|| PythonParse::default().python_parse(py, &json_data).unwrap());
+        });
+    });
 }
 
 fn python_parse_string_array_unique_not_cached(c: &mut Criterion) {
@@ -131,8 +160,7 @@ criterion_group!(
     python_parse_string_array,
     python_parse_string_array_unique_not_cached,
     python_parse_string_array_unique,
-    python_parse_x100_not_cached,
-    python_parse_x100,
+    python_parse_long_strings,
     python_parse_true_object,
     python_parse_true_array,
     python_parse_massive_ints_array,


### PR DESCRIPTION
`python_parse_x100` and `python_parse_x100_not_cached` do identical work, since a 100-character string is over the string cache's 64-byte limit either way, yet they measured 164 ns and 152 ns in the same CodSpeed run, and the pair has flipped between 128 and 164 ns on commits that don't touch string parsing (most recently on #295, where a rerun of the identical binary went from 164 ns back to 134 ns). At 130 ns the benchmark measures where pymalloc placed one string object, not the parser.

The path they covered, uncached creation of strings too long for the cache, was otherwise unmeasured on the Python side (string_array is 3-character strings, string_array_unique 5, true_object 4), so keep it but over 1000 ASCII strings of 64 to 2000 characters. Placement effects average out over a thousand allocations and the iteration is ~100 µs, so a 30 ns placement shift is 0.03% rather than 25%. One variant is enough since the cache doesn't apply above 64 bytes. The input is generated in the bench from a fixed seed, so nothing is checked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm4KCoN9xWsA4HRCL3Lx63


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the `python_parse_x100` and `python_parse_x100_not_cached` benchmarks with a single `python_parse_long_strings` benchmark over a thousand ASCII strings of 64 to 2000 characters. The old 100-character benchmarks measured pymalloc placement noise rather than parser performance; the new benchmark averages over many allocations, so placement shifts become negligible.

- The input is generated from a fixed seed, so no large JSON file is checked in.
- One variant covers both cache modes since strings exceed the 64-byte cache limit.

<sup>Written for commit fd42ac06b1248b1880e0903dcd4ee2293771028a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/jiter/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

